### PR TITLE
feat!: proto3 JSON serializer and deserializer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,71 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+name: ci
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [10, 12, 14, 15]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - run: node --version
+      # The first installation step ensures that all of our production
+      # dependencies work on the given Node.js version, this helps us find
+      # dependencies that don't match our engines field:
+      - run: npm install --production --engine-strict --ignore-scripts --no-package-lock
+      # Clean up the production install, before installing dev/production:
+      - run: rm -rf node_modules
+      - run: npm install
+      - run: npm test
+        env:
+          MOCHA_THROW_DEPRECATION: false
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - run: npm install
+      - run: npm test
+        env:
+          MOCHA_THROW_DEPRECATION: false
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - run: npm install
+      - run: npm run lint
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - run: npm install
+      - run: npm run docs-test

--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -1,0 +1,48 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+'use strict';
+
+module.exports = {
+  opts: {
+    readme: './README.md',
+    package: './package.json',
+    template: './node_modules/jsdoc-fresh',
+    recurse: true,
+    verbose: true,
+    destination: './docs/'
+  },
+  plugins: [
+    'plugins/markdown',
+    'jsdoc-region-tag'
+  ],
+  source: {
+    excludePattern: '(^|\\/|\\\\)[._]',
+    include: [
+      'build/src'
+    ],
+    includePattern: '\\.js$'
+  },
+  templates: {
+    copyright: 'Copyright 2021 Google, LLC.',
+    includeDate: false,
+    sourceFiles: false,
+    systemName: 'proto3-json-serializer',
+    theme: 'lumen'
+  },
+  markdown: {
+    idInHeadings: true
+  }
+};

--- a/README.md
+++ b/README.md
@@ -1,1 +1,97 @@
-# proto3-json-serializer-nodejs
+# proto3 JSON serializer for TypeScript / JavaScript
+
+This library implements proto3 JSON serialization and deserialization for
+[protobuf.js](https://www.npmjs.com/package/protobufjs) protobuf objects
+according to the [spec](https://developers.google.com/protocol-buffers/docs/proto3#json).
+
+Note that the spec requires special representation of some `google.protobuf.*` types
+(`Value`, `Struct`, `Timestamp`, `Duration`, etc.), so you cannot just use `.toObject()`
+since the result won't be understood by protobuf in other languages.  Hence this module.
+
+JavaScript:
+
+```js
+const serializer = require('proto3-json-serializer');
+```
+
+TypeScript:
+
+```ts
+import * as serializer from 'proto3-json-serializer';
+```
+
+## Serialization: protobuf.js object to proto3 JSON
+
+```js
+const root = protobuf.loadSync('test.proto');
+const Type = root.lookupType('test.Message');
+const message = Type.fromObject({...});
+
+const serialized = serializer.toProto3JSON(message);
+```
+
+Serialization works with any object created by calling `.create()`, `.decode()`, or `.fromObject()`
+for a loaded protobuf type. It relies on the `$type` field so it will not work with a static object.
+
+## Deserialization: proto3 JSON to protobuf.js object
+
+To deserialize an object from proto3 JSON, we must know its type (as returned by `root.lookupType('...')`).
+Pass this type as the first parameter to `.fromProto3JSON`:
+
+```js
+const root = protobuf.loadSync('test.proto');
+const Type = root.lookupType('test.Message');
+const json = {...};
+
+const deserialized = serializer.fromProto3JSON(Type, json);
+```
+
+## Complete example
+```js
+const assert = require('assert');
+const path = require('path');
+const protobuf = require('protobufjs');
+const serializer = require('proto3-json-serializer');
+
+// We'll take sample protos from google-proto-files but the code will work with any protos
+const protos = require('google-proto-files');
+
+// Load some proto file
+const rpcProtos = protos.getProtoPath('rpc');
+const root = protobuf.loadSync([
+    path.join(rpcProtos, 'status.proto'),
+    path.join(rpcProtos, 'error_details.proto'),
+]);
+const Status = root.lookupType('google.rpc.Status');
+
+// If you have a protobuf object that follows proto3 JSON syntax
+// https://developers.google.com/protocol-buffers/docs/proto3#json
+// (this is an example of google.rpc.Status message in JSON)
+const json = {
+    code: 3,
+    message: 'Test error message',
+    details: [
+        {
+            '@type': 'google.rpc.BadRequest',
+            fieldViolations: [
+                {
+                    field: 'field',
+                    description: 'must not be null',
+                },
+            ],
+        },
+    ],
+};
+
+// You can deserialize it into a protobuf.js object:
+const deserialized = serializer.fromProto3JSON(Status, json);
+console.log(deserialized);
+
+// And serialize it back
+const serialized = serializer.toProto3JSON(deserialized);
+assert.deepStrictEqual(serialized, json);
+```
+
+## Disclaimer
+
+This is not an officially supported Google project.

--- a/owlbot.py
+++ b/owlbot.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import synthtool.languages.node as node
+
+node.owlbot_main(templates_excludes=["LICENSE", "README.md"])

--- a/package.json
+++ b/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "proto3-json-serializer",
+  "version": "0.1.0",
+  "repository": "googleapis/proto3-json-serializer-nodejs",
+  "description": "Support for proto3 JSON serialiazation/deserialization for protobuf.js",
+  "main": "build/src/index.js",
+  "types": "build/src/index.d.ts",
+  "files": [
+    "build/src"
+  ],
+  "license": "Apache-2.0",
+  "keywords": [
+    "protobufjs",
+    "protobuf.js",
+    "protobuf",
+    "proto3",
+    "json",
+    "serialization",
+    "deserialization"
+  ],
+  "scripts": {
+    "test": "c8 node -r source-map-support/register node_modules/.bin/mocha build/test/unit",
+    "system-test": "mocha build/test/system",
+    "lint": "gts lint",
+    "clean": "gts clean",
+    "compile": "tsc",
+    "fix": "gts fix",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile",
+    "posttest": "npm run lint",
+    "compile-test-protos": "cd test-fixtures/proto && pbjs -t json test.proto > test.json",
+    "docs": "jsdoc -c .jsdoc.js",
+    "docs-test": "linkinator docs",
+    "predocs-test": "npm run docs",
+    "samples-test": "cd samples/ && npm link ../ && npm test && cd ../"
+  },
+  "devDependencies": {
+    "@types/mocha": "^9.0.0",
+    "@types/node": "^14.11.2",
+    "c8": "^7.7.3",
+    "google-proto-files": "^2.4.0",
+    "gts": "^3.1.0",
+    "jsdoc": "^3.6.7",
+    "jsdoc-fresh": "^1.1.0",
+    "jsdoc-region-tag": "^1.3.0",
+    "linkinator": "^2.14.0",
+    "mocha": "^9.0.3",
+    "pack-n-play": "^1.0.0-2",
+    "protobufjs": "^6.11.2",
+    "source-map-support": "^0.5.19",
+    "typescript": "^4.0.3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "docs": "jsdoc -c .jsdoc.js",
     "docs-test": "linkinator docs",
     "predocs-test": "npm run docs",
-    "samples-test": "cd samples/ && npm link ../ && npm test && cd ../"
+    "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
+    "prelint": "cd samples; npm link ../; npm install"
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "deserialization"
   ],
   "scripts": {
-    "test": "c8 node -r source-map-support/register node_modules/.bin/mocha build/test/unit",
+    "test": "c8 node -r source-map-support/register node_modules/mocha/bin/mocha build/test/unit",
     "system-test": "mocha build/test/system",
     "lint": "gts lint",
     "clean": "gts clean",
@@ -33,7 +33,7 @@
     "docs-test": "linkinator docs",
     "predocs-test": "npm run docs",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
-    "prelint": "cd samples; npm link ../; npm install"
+    "prelint": "cd samples && npm link ../ && npm install"
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "deserialization"
   ],
   "scripts": {
-    "test": "c8 node -r source-map-support/register node_modules/mocha/bin/mocha build/test/unit",
+    "test": "c8 node_modules/mocha/bin/mocha build/test/unit",
     "system-test": "mocha build/test/system",
     "lint": "gts lint",
     "clean": "gts clean",
@@ -48,7 +48,6 @@
     "mocha": "^9.0.3",
     "pack-n-play": "^1.0.0-2",
     "protobufjs": "^6.11.2",
-    "source-map-support": "^0.5.19",
     "typescript": "^4.0.3"
   }
 }

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,50 @@
+[//]: # "This README.md file is auto-generated, all changes to this file will be lost."
+[//]: # "To regenerate it, use `python -m synthtool`."
+<img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
+
+# [Proto3 JSON serializer: Node.js Samples](https://github.com/googleapis/proto3-json-serializer-nodejs)
+
+[![Open in Cloud Shell][shell_img]][shell_link]
+
+
+
+## Table of Contents
+
+* [Before you begin](#before-you-begin)
+* [Samples](#samples)
+  * [Quickstart](#quickstart)
+
+## Before you begin
+
+Before running the samples, make sure you've followed the steps outlined in
+[Using the client library](https://github.com/googleapis/proto3-json-serializer-nodejs#using-the-client-library).
+
+`cd samples`
+
+`npm install`
+
+`cd ..`
+
+## Samples
+
+
+
+### Quickstart
+
+View the [source code](https://github.com/googleapis/proto3-json-serializer-nodejs/blob/master/samples/quickstart.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/proto3-json-serializer-nodejs&page=editor&open_in_editor=samples/quickstart.js,samples/README.md)
+
+__Usage:__
+
+
+`node samples/quickstart.js`
+
+
+
+
+
+
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
+[shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/proto3-json-serializer-nodejs&page=editor&open_in_editor=samples/README.md
+[product-docs]: https://googleapis.github.io/proto3-json-serializer-nodejs/

--- a/samples/package.json
+++ b/samples/package.json
@@ -1,0 +1,25 @@
+{
+  "description": "Samples for proto3-json-serializer.",
+  "license": "Apache-2.0",
+  "author": "Google LLC",
+  "engines": {
+    "node": ">=10"
+  },
+  "repository": "googleapis/proto3-json-serializer-nodejs",
+  "private": true,
+  "scripts": {
+    "test": "c8 mocha system-test"
+  },
+  "files": [
+    "*.js"
+  ],
+  "dependencies": {
+    "google-proto-files": "^2.4.0",
+    "proto3-json-serializer": "0.1.0",
+    "protobufjs": "^6.11.2"
+  },
+  "devDependencies": {
+    "c8": "^7.0.0",
+    "mocha": "^8.0.0"
+  }
+}

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -1,0 +1,70 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+function main() {
+  // [START proto3_json_quickstart]
+  function quickstart() {
+    const assert = require('assert');
+    const path = require('path');
+    const protobuf = require('protobufjs');
+    const serializer = require('proto3-json-serializer');
+
+    // We'll take sample protos from google-proto-files but the code will work with any protos
+    const protos = require('google-proto-files');
+
+    // Load some proto file
+    const rpcProtos = protos.getProtoPath('rpc');
+    const root = protobuf.loadSync([
+      path.join(rpcProtos, 'status.proto'),
+      path.join(rpcProtos, 'error_details.proto'),
+    ]);
+    const Status = root.lookupType('google.rpc.Status');
+
+    // If you have a protobuf object that follows proto3 JSON syntax
+    // https://developers.google.com/protocol-buffers/docs/proto3#json
+    // (this is an example of google.rpc.Status message in JSON)
+    const json = {
+      code: 3,
+      message: 'Test error message',
+      details: [
+        {
+          '@type': 'google.rpc.BadRequest',
+          fieldViolations: [
+            {
+              field: 'field',
+              description: 'must not be null',
+            },
+          ],
+        },
+      ],
+    };
+
+    // You can deserialize it into a protobuf.js object:
+    const deserialized = serializer.fromProto3JSON(Status, json);
+    console.log(deserialized);
+
+    // And serialize it back
+    const serialized = serializer.toProto3JSON(deserialized);
+    assert.deepStrictEqual(serialized, json);
+
+    console.log('Quickstart completed');
+  }
+  // [END proto3_json_quickstart]
+
+  quickstart();
+}
+
+main();

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -15,7 +15,7 @@
 'use strict';
 
 function main() {
-  // [START proto3_json_quickstart]
+  // [START proto3_json_serializer_quickstart]
   function quickstart() {
     const assert = require('assert');
     const path = require('path');
@@ -62,7 +62,7 @@ function main() {
 
     console.log('Quickstart completed');
   }
-  // [END proto3_json_quickstart]
+  // [END proto3_json_serializer_quickstart]
 
   quickstart();
 }

--- a/samples/system-test/test.quickstart.js
+++ b/samples/system-test/test.quickstart.js
@@ -1,0 +1,31 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const path = require('path');
+const assert = require('assert');
+const {describe, it} = require('mocha');
+const cp = require('child_process');
+
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+
+const cwd = path.join(__dirname, '..');
+
+describe('Quickstart', () => {
+  it('should run quickstart sample', async () => {
+    const stdout = execSync('node quickstart.js', {cwd});
+    assert(/Quickstart completed/.test(stdout));
+  });
+});

--- a/test-fixtures/proto/test.json
+++ b/test-fixtures/proto/test.json
@@ -1,0 +1,450 @@
+{
+  "nested": {
+    "test": {
+      "nested": {
+        "PrimitiveTypes": {
+          "fields": {
+            "integerField": {
+              "type": "int32",
+              "id": 1
+            },
+            "unsignedIntegerField": {
+              "type": "uint32",
+              "id": 2
+            },
+            "fixedIntegerField": {
+              "type": "fixed32",
+              "id": 3
+            },
+            "stringField": {
+              "type": "string",
+              "id": 4
+            },
+            "boolField": {
+              "type": "bool",
+              "id": 5
+            },
+            "int64Field": {
+              "type": "int64",
+              "id": 6
+            },
+            "uint64Field": {
+              "type": "uint64",
+              "id": 7
+            }
+          }
+        },
+        "MessageWithNestedMessage": {
+          "fields": {
+            "innerMessage": {
+              "type": "AnyContent",
+              "id": 1
+            }
+          }
+        },
+        "MessageWithAny": {
+          "fields": {
+            "anyField": {
+              "type": "google.protobuf.Any",
+              "id": 3
+            }
+          }
+        },
+        "AnyContent": {
+          "fields": {
+            "stringField": {
+              "type": "string",
+              "id": 1
+            }
+          }
+        },
+        "MessageWithBytesField": {
+          "fields": {
+            "bytesField": {
+              "type": "bytes",
+              "id": 3
+            }
+          }
+        },
+        "MessageWithMap": {
+          "fields": {
+            "mapField": {
+              "keyType": "string",
+              "type": "MapValue",
+              "id": 3
+            },
+            "stringMapField": {
+              "keyType": "string",
+              "type": "string",
+              "id": 4
+            }
+          }
+        },
+        "MapValue": {
+          "fields": {
+            "stringField": {
+              "type": "string",
+              "id": 1
+            }
+          }
+        },
+        "MessageWithRepeated": {
+          "fields": {
+            "repeatedString": {
+              "rule": "repeated",
+              "type": "string",
+              "id": 3
+            },
+            "repeatedMessage": {
+              "rule": "repeated",
+              "type": "RepeatedValue",
+              "id": 4
+            }
+          }
+        },
+        "RepeatedValue": {
+          "fields": {
+            "stringField": {
+              "type": "string",
+              "id": 1
+            }
+          }
+        },
+        "Enum": {
+          "values": {
+            "UNKNOWN": 0,
+            "KNOWN": 1
+          }
+        },
+        "MessageWithEnum": {
+          "fields": {
+            "enumField": {
+              "type": "Enum",
+              "id": 3
+            }
+          }
+        },
+        "MessageWithOneof": {
+          "oneofs": {
+            "_oneofField": {
+              "oneof": [
+                "stringField",
+                "integerField",
+                "messageField"
+              ]
+            }
+          },
+          "fields": {
+            "stringField": {
+              "type": "string",
+              "id": 1
+            },
+            "integerField": {
+              "type": "int32",
+              "id": 2
+            },
+            "messageField": {
+              "type": "AnyContent",
+              "id": 3
+            }
+          }
+        },
+        "MessageWithValue": {
+          "fields": {
+            "valueField": {
+              "type": "google.protobuf.Value",
+              "id": 1
+            }
+          }
+        },
+        "MessageWithStruct": {
+          "fields": {
+            "structField": {
+              "type": "google.protobuf.Struct",
+              "id": 1
+            }
+          }
+        },
+        "MessageWithListValue": {
+          "fields": {
+            "listValueField": {
+              "type": "google.protobuf.ListValue",
+              "id": 1
+            }
+          }
+        },
+        "MessageWithNullValue": {
+          "fields": {
+            "nullValueField": {
+              "type": "google.protobuf.NullValue",
+              "id": 1
+            }
+          }
+        },
+        "MessageWithDuration": {
+          "fields": {
+            "durationField": {
+              "type": "google.protobuf.Duration",
+              "id": 1
+            }
+          }
+        },
+        "MessageWithTimestamp": {
+          "fields": {
+            "timestampField": {
+              "type": "google.protobuf.Timestamp",
+              "id": 1
+            }
+          }
+        },
+        "MessageWithEmpty": {
+          "fields": {
+            "emptyField": {
+              "type": "google.protobuf.Empty",
+              "id": 1
+            }
+          }
+        },
+        "MessageWithWrappers": {
+          "fields": {
+            "doubleValueField": {
+              "type": "google.protobuf.DoubleValue",
+              "id": 1
+            },
+            "floatValueField": {
+              "type": "google.protobuf.FloatValue",
+              "id": 2
+            },
+            "int64ValueField": {
+              "type": "google.protobuf.Int64Value",
+              "id": 3
+            },
+            "uint64ValueField": {
+              "type": "google.protobuf.UInt64Value",
+              "id": 4
+            },
+            "int32ValueField": {
+              "type": "google.protobuf.Int32Value",
+              "id": 5
+            },
+            "uint32ValueField": {
+              "type": "google.protobuf.UInt32Value",
+              "id": 6
+            },
+            "boolValueField": {
+              "type": "google.protobuf.BoolValue",
+              "id": 7
+            },
+            "stringValueField": {
+              "type": "google.protobuf.StringValue",
+              "id": 8
+            },
+            "bytesValueField": {
+              "type": "google.protobuf.BytesValue",
+              "id": 9
+            }
+          }
+        },
+        "MessageWithFieldMask": {
+          "fields": {
+            "fieldMaskField": {
+              "type": "google.protobuf.FieldMask",
+              "id": 1
+            }
+          }
+        }
+      }
+    },
+    "google": {
+      "nested": {
+        "protobuf": {
+          "nested": {
+            "Any": {
+              "fields": {
+                "type_url": {
+                  "type": "string",
+                  "id": 1
+                },
+                "value": {
+                  "type": "bytes",
+                  "id": 2
+                }
+              }
+            },
+            "Duration": {
+              "fields": {
+                "seconds": {
+                  "type": "int64",
+                  "id": 1
+                },
+                "nanos": {
+                  "type": "int32",
+                  "id": 2
+                }
+              }
+            },
+            "Empty": {
+              "fields": {}
+            },
+            "FieldMask": {
+              "fields": {
+                "paths": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 1
+                }
+              }
+            },
+            "Struct": {
+              "fields": {
+                "fields": {
+                  "keyType": "string",
+                  "type": "Value",
+                  "id": 1
+                }
+              }
+            },
+            "Value": {
+              "oneofs": {
+                "kind": {
+                  "oneof": [
+                    "nullValue",
+                    "numberValue",
+                    "stringValue",
+                    "boolValue",
+                    "structValue",
+                    "listValue"
+                  ]
+                }
+              },
+              "fields": {
+                "nullValue": {
+                  "type": "NullValue",
+                  "id": 1
+                },
+                "numberValue": {
+                  "type": "double",
+                  "id": 2
+                },
+                "stringValue": {
+                  "type": "string",
+                  "id": 3
+                },
+                "boolValue": {
+                  "type": "bool",
+                  "id": 4
+                },
+                "structValue": {
+                  "type": "Struct",
+                  "id": 5
+                },
+                "listValue": {
+                  "type": "ListValue",
+                  "id": 6
+                }
+              }
+            },
+            "NullValue": {
+              "values": {
+                "NULL_VALUE": 0
+              }
+            },
+            "ListValue": {
+              "fields": {
+                "values": {
+                  "rule": "repeated",
+                  "type": "Value",
+                  "id": 1
+                }
+              }
+            },
+            "Timestamp": {
+              "fields": {
+                "seconds": {
+                  "type": "int64",
+                  "id": 1
+                },
+                "nanos": {
+                  "type": "int32",
+                  "id": 2
+                }
+              }
+            },
+            "DoubleValue": {
+              "fields": {
+                "value": {
+                  "type": "double",
+                  "id": 1
+                }
+              }
+            },
+            "FloatValue": {
+              "fields": {
+                "value": {
+                  "type": "float",
+                  "id": 1
+                }
+              }
+            },
+            "Int64Value": {
+              "fields": {
+                "value": {
+                  "type": "int64",
+                  "id": 1
+                }
+              }
+            },
+            "UInt64Value": {
+              "fields": {
+                "value": {
+                  "type": "uint64",
+                  "id": 1
+                }
+              }
+            },
+            "Int32Value": {
+              "fields": {
+                "value": {
+                  "type": "int32",
+                  "id": 1
+                }
+              }
+            },
+            "UInt32Value": {
+              "fields": {
+                "value": {
+                  "type": "uint32",
+                  "id": 1
+                }
+              }
+            },
+            "BoolValue": {
+              "fields": {
+                "value": {
+                  "type": "bool",
+                  "id": 1
+                }
+              }
+            },
+            "StringValue": {
+              "fields": {
+                "value": {
+                  "type": "string",
+                  "id": 1
+                }
+              }
+            },
+            "BytesValue": {
+              "fields": {
+                "value": {
+                  "type": "bytes",
+                  "id": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test-fixtures/proto/test.proto
+++ b/test-fixtures/proto/test.proto
@@ -1,0 +1,130 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+package test;
+
+message PrimitiveTypes {
+    int32 integer_field = 1;
+    uint32 unsigned_integer_field = 2;
+    fixed32 fixed_integer_field = 3;
+    string string_field = 4;
+    bool bool_field = 5;
+    int64 int64_field = 6;
+    uint64 uint64_field = 7;
+}
+
+message MessageWithNestedMessage {
+    AnyContent inner_message = 1;
+}
+
+message MessageWithAny {
+    google.protobuf.Any any_field = 3;
+}
+
+message AnyContent {
+    string string_field = 1;
+}
+
+message MessageWithBytesField {
+    bytes bytes_field = 3;
+}
+
+message MessageWithMap {
+    map<string, MapValue> map_field = 3;
+    map<string, string> string_map_field = 4;
+}
+
+message MapValue {
+    string string_field = 1;
+}
+
+message MessageWithRepeated {
+    repeated string repeated_string = 3;
+    repeated RepeatedValue repeated_message = 4;    
+}
+
+message RepeatedValue {
+    string string_field = 1;
+}
+
+enum Enum {
+    UNKNOWN = 0;
+    KNOWN = 1;
+}
+
+message MessageWithEnum {
+    Enum enum_field = 3;
+}
+
+message MessageWithOneof {
+    oneof _oneof_field {
+        string string_field = 1;
+        int32 integer_field = 2;
+        AnyContent message_field = 3;
+    }
+}
+
+message MessageWithValue {
+    google.protobuf.Value value_field = 1;
+}
+
+message MessageWithStruct {
+    google.protobuf.Struct struct_field = 1;
+}
+
+message MessageWithListValue {
+    google.protobuf.ListValue list_value_field = 1;
+}
+
+message MessageWithNullValue {
+    google.protobuf.NullValue null_value_field = 1;
+}
+
+message MessageWithDuration {
+    google.protobuf.Duration duration_field = 1;
+}
+
+message MessageWithTimestamp {
+    google.protobuf.Timestamp timestamp_field = 1;
+}
+
+message MessageWithEmpty {
+    google.protobuf.Empty empty_field = 1;
+}
+
+message MessageWithWrappers {
+    google.protobuf.DoubleValue double_value_field = 1;
+    google.protobuf.FloatValue float_value_field = 2;
+    google.protobuf.Int64Value int64_value_field = 3;
+    google.protobuf.UInt64Value uint64_value_field = 4;
+    google.protobuf.Int32Value int32_value_field = 5;
+    google.protobuf.UInt32Value uint32_value_field = 6;
+    google.protobuf.BoolValue bool_value_field = 7;
+    google.protobuf.StringValue string_value_field = 8;
+    google.protobuf.BytesValue bytes_value_field = 9;
+}
+
+message MessageWithFieldMask {
+    google.protobuf.FieldMask field_mask_field = 1;
+}

--- a/typescript/src/any.ts
+++ b/typescript/src/any.ts
@@ -1,0 +1,123 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Types that have special JSON representation according to https://developers.google.com/protocol-buffers/docs/proto3#json
+// (this set is used for encoding google.protobuf.Any to/from proto3 JSON properly)
+
+import * as protobuf from 'protobufjs';
+import {fromProto3JSON} from './fromproto3json';
+import {toProto3JSON} from './toproto3json';
+import {JSONObject, JSONValue} from './types';
+
+// https://github.com/protocolbuffers/protobuf/blob/ba3836703b4a9e98e474aea2bac8c5b49b6d3b5c/python/google/protobuf/json_format.py#L850
+const specialJSON = new Set([
+  'google.protobuf.Any',
+  'google.protobuf.Duration',
+  'google.protobuf.FieldMask',
+  'google.protobuf.ListValue',
+  'google.protobuf.Struct',
+  'google.protobuf.Timestamp',
+  'google.protobuf.Value',
+]);
+
+export interface Any {
+  type_url: string;
+  value: Buffer | Uint8Array;
+}
+
+export function googleProtobufAnyToProto3JSON(
+  obj: protobuf.Message & Any
+): JSONObject {
+  // https://developers.google.com/protocol-buffers/docs/proto3#json
+  // If the Any contains a value that has a special JSON mapping, it will be converted as follows:
+  // {"@type": xxx, "value": yyy}.
+  // Otherwise, the value will be converted into a JSON object, and the "@type" field will be inserted
+  // to indicate the actual data type.
+
+  const typeName = obj.type_url.replace(/^.*\//, '');
+  let type: protobuf.Type;
+  try {
+    type = obj.$type.root.lookupType(typeName);
+  } catch (err) {
+    throw new Error(
+      `googleProtobufAnyToProto3JSON: cannot find type ${typeName}: ${err}`
+    );
+  }
+  const valueMessage = type.decode(obj.value);
+  const valueProto3JSON = toProto3JSON(valueMessage);
+  if (specialJSON.has(typeName)) {
+    return {
+      '@type': obj.type_url,
+      value: valueProto3JSON,
+    };
+  }
+  (valueProto3JSON as JSONObject)['@type'] = obj.type_url;
+  return valueProto3JSON as JSONObject;
+}
+
+export function googleProtobufAnyFromProto3JSON(
+  root: protobuf.Root,
+  json: JSONValue
+) {
+  // Not all possible JSON values can hold Any, only real objects.
+  if (json === null || typeof json !== 'object' || Array.isArray(json)) {
+    throw new Error(
+      'googleProtobufAnyFromProto3JSON: must be an object to decode google.protobuf.Any'
+    );
+  }
+
+  const typeUrl = json['@type'];
+  if (!typeUrl || typeof typeUrl !== 'string') {
+    throw new Error(
+      'googleProtobufAnyFromProto3JSON: JSON serialization of google.protobuf.Any must contain @type field'
+    );
+  }
+
+  const typeName = typeUrl.replace(/^.*\//, '');
+  let type: protobuf.Type;
+  try {
+    type = root.lookupType(typeName);
+  } catch (err) {
+    throw new Error(
+      `googleProtobufAnyFromProto3JSON: cannot find type ${typeName}: ${err}`
+    );
+  }
+
+  let value: JSONValue = json;
+  if (specialJSON.has(typeName)) {
+    if (!('value' in json)) {
+      throw new Error(
+        `googleProtobufAnyFromProto3JSON: JSON representation of google.protobuf.Any with type ${typeName} must contain the value field`
+      );
+    }
+    value = json.value;
+  }
+
+  const valueMessage = fromProto3JSON(type, value);
+  if (valueMessage === null) {
+    return {
+      type_url: typeUrl,
+      value: null,
+    };
+  }
+
+  const uint8array = type.encode(valueMessage).finish();
+  const buffer = Buffer.from(uint8array, 0, uint8array.byteLength);
+  const base64 = buffer.toString('base64');
+
+  return {
+    type_url: typeUrl,
+    value: base64,
+  };
+}

--- a/typescript/src/bytes.ts
+++ b/typescript/src/bytes.ts
@@ -1,0 +1,25 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export function bytesToProto3JSON(obj: Buffer | Uint8Array) {
+  if (Buffer.isBuffer(obj)) {
+    return obj.toString('base64');
+  } else {
+    return Buffer.from(obj.buffer, 0, obj.byteLength).toString('base64');
+  }
+}
+
+export function bytesFromProto3JSON(json: string) {
+  return Buffer.from(json, 'base64');
+}

--- a/typescript/src/duration.ts
+++ b/typescript/src/duration.ts
@@ -1,0 +1,67 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as protobuf from 'protobufjs';
+import {FromObjectValue} from './types';
+
+export interface Duration {
+  seconds: number; // it's technically Long but we don't want to bring it as a dependency for now
+  nanos?: number;
+}
+
+export function googleProtobufDurationToProto3JSON(
+  obj: protobuf.Message & Duration
+) {
+  // seconds is an instance of Long so it won't be undefined
+  let durationSeconds = obj.seconds.toString();
+  if (typeof obj.nanos === 'number' && obj.nanos > 0) {
+    // nanosStr should contain 3, 6, or 9 fractional digits.
+    const nanosStr = obj.nanos
+      .toString()
+      .padStart(9, '0')
+      .replace(/^((?:\d\d\d)+?)(?:0*)$/, '$1');
+    durationSeconds += '.' + nanosStr;
+  }
+  durationSeconds += 's';
+  return durationSeconds;
+}
+
+export function googleProtobufDurationFromProto3JSON(json: string) {
+  const match = json.match(/^(\d*)(?:\.(\d*))?s$/);
+  if (!match) {
+    throw new Error(
+      `googleProtobufDurationFromProto3JSON: incorrect value ${json} passed as google.protobuf.Duration`
+    );
+  }
+
+  let seconds = 0;
+  let nanos = 0;
+
+  if (typeof match[1] === 'string' && match[1].length > 0) {
+    seconds = parseInt(match[1]);
+  }
+
+  if (typeof match[2] === 'string' && match[2].length > 0) {
+    nanos = parseInt(match[2].padEnd(9, '0'));
+  }
+
+  const result: FromObjectValue = {};
+  if (seconds !== 0) {
+    result.seconds = seconds;
+  }
+  if (nanos !== 0) {
+    result.nanos = nanos;
+  }
+  return result;
+}

--- a/typescript/src/enum.ts
+++ b/typescript/src/enum.ts
@@ -1,0 +1,39 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as protobuf from 'protobufjs';
+import {JSONValue} from './types';
+
+export function resolveEnumValueToString(
+  enumType: protobuf.Enum,
+  enumValue: JSONValue
+) {
+  if (typeof enumValue === 'number') {
+    const value = enumType.valuesById[enumValue];
+    if (typeof value === 'undefined') {
+      throw new Error(`enumFromProto3JSON: unknown value id ${enumValue}`);
+    }
+    return value;
+  }
+  if (typeof enumValue === 'string') {
+    const id = enumType.values[enumValue];
+    if (typeof id === 'undefined') {
+      throw new Error(`enumFromProto3JSON: unknown value ${enumValue}`);
+    }
+    return enumValue;
+  }
+  throw new Error(
+    'resolveEnumValueToString: enum value must be a string or a number'
+  );
+}

--- a/typescript/src/fieldmask.ts
+++ b/typescript/src/fieldmask.ts
@@ -1,0 +1,31 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as protobuf from 'protobufjs';
+
+export interface FieldMask {
+  paths: string[];
+}
+
+export function googleProtobufFieldMaskToProto3JSON(
+  obj: protobuf.Message & FieldMask
+) {
+  return obj.paths.join(',');
+}
+
+export function googleProtobufFieldMaskFromProto3JSON(json: string) {
+  return {
+    paths: json.split(','),
+  };
+}

--- a/typescript/src/fromproto3json.ts
+++ b/typescript/src/fromproto3json.ts
@@ -1,0 +1,221 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {googleProtobufAnyFromProto3JSON} from './any';
+import {bytesFromProto3JSON} from './bytes';
+import {resolveEnumValueToString} from './enum';
+import {FromObjectValue, JSONValue} from './types';
+import {
+  googleProtobufListValueFromProto3JSON,
+  googleProtobufStructFromProto3JSON,
+  googleProtobufValueFromProto3JSON,
+} from './value';
+import {getFullyQualifiedTypeName, wrapperTypes} from './util';
+import {googleProtobufDurationFromProto3JSON} from './duration';
+import {googleProtobufTimestampFromProto3JSON} from './timestamp';
+import {wrapperFromProto3JSON} from './wrappers';
+import {googleProtobufFieldMaskFromProto3JSON} from './fieldmask';
+
+export function fromProto3JSONToInternalRepresentation(
+  type: protobuf.Type | protobuf.Enum | string,
+  json: JSONValue
+): FromObjectValue {
+  const fullyQualifiedTypeName =
+    typeof type === 'string' ? type : getFullyQualifiedTypeName(type);
+
+  if (typeof type !== 'string' && 'values' in type) {
+    // type is an Enum
+    if (fullyQualifiedTypeName === '.google.protobuf.NullValue') {
+      return 'NULL_VALUE';
+    }
+
+    return resolveEnumValueToString(type, json);
+  }
+
+  if (typeof type !== 'string') {
+    type.resolveAll();
+  }
+
+  if (typeof type === 'string') {
+    return json;
+  }
+
+  // Types that require special handling according to
+  // https://developers.google.com/protocol-buffers/docs/proto3#json
+
+  // Types that can have meaningful "null" value
+  if (fullyQualifiedTypeName === '.google.protobuf.Value') {
+    return googleProtobufValueFromProto3JSON(json);
+  }
+
+  if (wrapperTypes.has(fullyQualifiedTypeName)) {
+    if ((json !== null && typeof json === 'object') || Array.isArray(json)) {
+      throw new Error(
+        `fromProto3JSONToInternalRepresentation: JSON representation for ${fullyQualifiedTypeName} expects a string, a number, or a boolean, but got ${typeof json}`
+      );
+    }
+    return wrapperFromProto3JSON(fullyQualifiedTypeName, json);
+  }
+
+  if (json === null) {
+    return null;
+  }
+
+  // Types that cannot be "null"
+  if (fullyQualifiedTypeName === '.google.protobuf.Any') {
+    return googleProtobufAnyFromProto3JSON(type.root, json);
+  }
+
+  if (fullyQualifiedTypeName === '.google.protobuf.Struct') {
+    if (typeof json !== 'object') {
+      throw new Error(
+        `fromProto3JSONToInternalRepresentation: google.protobuf.Struct must be an object but got ${typeof json}`
+      );
+    }
+    if (Array.isArray(json)) {
+      throw new Error(
+        'fromProto3JSONToInternalRepresentation: google.protobuf.Struct must be an object but got an array'
+      );
+    }
+    return googleProtobufStructFromProto3JSON(json);
+  }
+
+  if (fullyQualifiedTypeName === '.google.protobuf.ListValue') {
+    if (!Array.isArray(json)) {
+      throw new Error(
+        `fromProto3JSONToInternalRepresentation: google.protobuf.ListValue must be an array but got ${typeof json}`
+      );
+    }
+    return googleProtobufListValueFromProto3JSON(json);
+  }
+
+  if (fullyQualifiedTypeName === '.google.protobuf.Duration') {
+    if (typeof json !== 'string') {
+      throw new Error(
+        `fromProto3JSONToInternalRepresentation: google.protobuf.Duration must be a string but got ${typeof json}`
+      );
+    }
+    return googleProtobufDurationFromProto3JSON(json);
+  }
+
+  if (fullyQualifiedTypeName === '.google.protobuf.Timestamp') {
+    if (typeof json !== 'string') {
+      throw new Error(
+        `fromProto3JSONToInternalRepresentation: google.protobuf.Timestamp must be a string but got ${typeof json}`
+      );
+    }
+    return googleProtobufTimestampFromProto3JSON(json);
+  }
+
+  if (fullyQualifiedTypeName === '.google.protobuf.FieldMask') {
+    if (typeof json !== 'string') {
+      throw new Error(
+        `fromProto3JSONToInternalRepresentation: google.protobuf.FieldMask must be a string but got ${typeof json}`
+      );
+    }
+    return googleProtobufFieldMaskFromProto3JSON(json);
+  }
+
+  const result: FromObjectValue = {};
+  for (const [key, value] of Object.entries(json)) {
+    const field = type.fields[key];
+    if (!field) {
+      continue;
+    }
+
+    const resolvedType = field.resolvedType;
+    const fieldType = field.type;
+
+    if (field.repeated) {
+      if (!Array.isArray(value)) {
+        throw new Error(
+          `fromProto3JSONToInternalRepresentation: expected an array for field ${key}`
+        );
+      }
+      result[key] = value.map(element =>
+        fromProto3JSONToInternalRepresentation(
+          resolvedType || fieldType,
+          element
+        )
+      );
+    } else if (field.map) {
+      const map: FromObjectValue = {};
+      for (const [mapKey, mapValue] of Object.entries(value)) {
+        map[mapKey] = fromProto3JSONToInternalRepresentation(
+          resolvedType || fieldType,
+          mapValue as JSONValue
+        );
+      }
+      result[key] = map;
+    } else if (
+      fieldType.match(/^(?:(?:(?:u?int|fixed)(?:32|64))|float|double)$/)
+    ) {
+      if (typeof value !== 'number') {
+        throw new Error(
+          `fromProto3JSONToInternalRepresentation: field ${key} of type ${field.type} cannot contain value ${value}`
+        );
+      }
+      result[key] = value;
+    } else if (fieldType === 'string') {
+      if (typeof value !== 'string') {
+        throw new Error(
+          `fromProto3JSONToInternalRepresentation: field ${key} of type ${field.type} cannot contain value ${value}`
+        );
+      }
+      result[key] = value;
+    } else if (fieldType === 'bool') {
+      if (typeof value !== 'boolean') {
+        throw new Error(
+          `fromProto3JSONToInternalRepresentation: field ${key} of type ${field.type} cannot contain value ${value}`
+        );
+      }
+      result[key] = value;
+    } else if (fieldType === 'bytes') {
+      if (typeof value !== 'string') {
+        throw new Error(
+          `fromProto3JSONToInternalRepresentation: field ${key} of type ${field.type} cannot contain value ${value}`
+        );
+      }
+      result[key] = bytesFromProto3JSON(value);
+    } else {
+      // Message type
+      assert(
+        resolvedType,
+        `Expected to be able to resolve type for field ${field.name}`
+      );
+      const deserializedValue = fromProto3JSONToInternalRepresentation(
+        resolvedType,
+        value
+      );
+      result[key] = deserializedValue;
+    }
+  }
+
+  return result;
+}
+
+export function fromProto3JSON(type: protobuf.Type, json: JSONValue) {
+  const internalRepr = fromProto3JSONToInternalRepresentation(type, json);
+  if (internalRepr === null) {
+    return null;
+  }
+  // We only expect a real object here sine all special cases should be already resolved. Everything else is an internal error
+  assert(
+    typeof internalRepr === 'object' && !Array.isArray(internalRepr),
+    `fromProto3JSON: expected an object, not ${json}`
+  );
+  return type.fromObject(internalRepr);
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,0 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export {JSONObject, JSONValue} from './types';
+export {toProto3JSON} from './toproto3json';
+export {fromProto3JSON} from './fromproto3json';

--- a/typescript/src/timestamp.ts
+++ b/typescript/src/timestamp.ts
@@ -1,0 +1,56 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as protobuf from 'protobufjs';
+import {FromObjectValue} from './types';
+
+export interface Timestamp {
+  seconds: number; // it's technically Long but we don't want to bring it as a dependency for now
+  nanos?: number;
+}
+
+export function googleProtobufTimestampToProto3JSON(
+  obj: protobuf.Message & Timestamp
+) {
+  // seconds is an instance of Long so it won't be undefined
+  const durationSeconds = obj.seconds;
+  const durationMilliseconds =
+    typeof obj.nanos === 'number' && obj.nanos > 0
+      ? Math.floor(obj.nanos / 1000000)
+      : 0;
+  return new Date(durationSeconds * 1000 + durationMilliseconds).toISOString();
+}
+
+export function googleProtobufTimestampFromProto3JSON(json: string) {
+  const match = json.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?/);
+  if (!match) {
+    throw new Error(
+      `googleProtobufDurationFromProto3JSON: incorrect value ${json} passed as google.protobuf.Duration`
+    );
+  }
+
+  const date = new Date(json);
+  const millisecondsSinceEpoch = date.getTime();
+  const seconds = Math.floor(millisecondsSinceEpoch / 1000);
+  const nanos = (millisecondsSinceEpoch % 1000) * 1000000;
+
+  const result: FromObjectValue = {};
+  if (seconds !== 0) {
+    result.seconds = seconds;
+  }
+  if (nanos !== 0) {
+    result.nanos = nanos;
+  }
+  return result;
+}

--- a/typescript/src/toproto3json.ts
+++ b/typescript/src/toproto3json.ts
@@ -1,0 +1,167 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import {JSONObject, JSONValue, LongStub} from './types';
+import {Any, googleProtobufAnyToProto3JSON} from './any';
+import {bytesToProto3JSON} from './bytes';
+import {getFullyQualifiedTypeName, wrapperTypes} from './util';
+import {resolveEnumValueToString} from './enum';
+import {
+  googleProtobufListValueToProto3JSON,
+  googleProtobufStructToProto3JSON,
+  googleProtobufValueToProto3JSON,
+  ListValue,
+  Struct,
+  Value,
+} from './value';
+import {Duration, googleProtobufDurationToProto3JSON} from './duration';
+import {googleProtobufTimestampToProto3JSON, Timestamp} from './timestamp';
+import {
+  BoolValue,
+  BytesValue,
+  NumberValue,
+  StringValue,
+  wrapperToProto3JSON,
+} from './wrappers';
+import {FieldMask, googleProtobufFieldMaskToProto3JSON} from './fieldmask';
+
+const id = (x: JSONValue) => {
+  return x;
+};
+
+export function toProto3JSON(obj: protobuf.Message): JSONValue {
+  const objType = obj.$type;
+  if (!objType) {
+    throw new Error(
+      'Cannot serialize object to proto3 JSON since its .$type is unknown. Use Type.fromObject(obj) before calling toProto3JSON.'
+    );
+  }
+
+  objType.resolveAll();
+  const typeName = getFullyQualifiedTypeName(objType);
+
+  // Types that require special handling according to
+  // https://developers.google.com/protocol-buffers/docs/proto3#json
+  if (typeName === '.google.protobuf.Any') {
+    return googleProtobufAnyToProto3JSON(obj as protobuf.Message & Any);
+  }
+
+  if (typeName === '.google.protobuf.Value') {
+    return googleProtobufValueToProto3JSON(obj as protobuf.Message & Value);
+  }
+
+  if (typeName === '.google.protobuf.Struct') {
+    return googleProtobufStructToProto3JSON(obj as protobuf.Message & Struct);
+  }
+
+  if (typeName === '.google.protobuf.ListValue') {
+    return googleProtobufListValueToProto3JSON(
+      obj as protobuf.Message & ListValue
+    );
+  }
+
+  if (typeName === '.google.protobuf.Duration') {
+    return googleProtobufDurationToProto3JSON(
+      obj as protobuf.Message & Duration
+    );
+  }
+
+  if (typeName === '.google.protobuf.Timestamp') {
+    return googleProtobufTimestampToProto3JSON(
+      obj as protobuf.Message & Timestamp
+    );
+  }
+
+  if (typeName === '.google.protobuf.FieldMask') {
+    return googleProtobufFieldMaskToProto3JSON(
+      obj as protobuf.Message & FieldMask
+    );
+  }
+
+  if (wrapperTypes.has(typeName)) {
+    return wrapperToProto3JSON(
+      obj as protobuf.Message &
+        (NumberValue | StringValue | BoolValue | BytesValue)
+    );
+  }
+
+  const result: JSONObject = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const field = objType.fields[key];
+    const fieldResolvedType = field.resolvedType;
+    const fieldFullyQualifiedTypeName = fieldResolvedType
+      ? getFullyQualifiedTypeName(fieldResolvedType)
+      : null;
+    if (value === null) {
+      result[key] = null;
+      continue;
+    }
+    if (Array.isArray(value)) {
+      // if the repeated value has a complex type, convert it to proto3 JSON, otherwise use as is
+      result[key] = value.map(
+        fieldResolvedType
+          ? element => {
+              return toProto3JSON(element);
+            }
+          : id
+      );
+      continue;
+    }
+    if (field.map) {
+      const map: JSONObject = {};
+      for (const [mapKey, mapValue] of Object.entries(value)) {
+        // if the map value has a complex type, convert it to proto3 JSON, otherwise use as is
+        map[mapKey] = fieldResolvedType
+          ? toProto3JSON(mapValue as protobuf.Message)
+          : (mapValue as JSONValue);
+      }
+      result[key] = map;
+      continue;
+    }
+    if (fieldFullyQualifiedTypeName === '.google.protobuf.NullValue') {
+      result[key] = null;
+      continue;
+    }
+    if (fieldResolvedType && 'values' in fieldResolvedType && value !== null) {
+      result[key] = resolveEnumValueToString(fieldResolvedType, value);
+      continue;
+    }
+    if (fieldResolvedType) {
+      result[key] = toProto3JSON(value);
+      continue;
+    }
+    if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean' ||
+      value === null
+    ) {
+      result[key] = value;
+      continue;
+    }
+    if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+      result[key] = bytesToProto3JSON(value);
+      continue;
+    }
+    // The remaining case is Long, everything else is an internal error
+    assert(
+      value.constructor.name === 'Long',
+      `toProto3JSON: don't know how to convert field ${key} with value ${value}`
+    );
+    result[key] = (value as LongStub).toNumber();
+    continue;
+  }
+  return result;
+}

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JSONValue[]
+  | {[key: string]: JSONValue};
+
+export interface JSONObject {
+  [key: string]: JSONValue;
+}
+
+export type FromObjectValue =
+  | string
+  | number
+  | boolean
+  | null
+  | FromObjectValue[]
+  | Buffer
+  | Uint8Array
+  | {[key: string]: FromObjectValue};
+
+// We don't want to import long here, we only need .toNumber() from it
+export interface LongStub {
+  toNumber: () => number;
+}

--- a/typescript/src/util.ts
+++ b/typescript/src/util.ts
@@ -1,0 +1,37 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export function getFullyQualifiedTypeName(
+  type: protobuf.Type | protobuf.Namespace | protobuf.Enum
+) {
+  // We assume that the protobuf package tree cannot have cycles.
+  let fullyQualifiedTypeName = '';
+  while (type.parent) {
+    fullyQualifiedTypeName = `.${type.name}${fullyQualifiedTypeName}`;
+    type = type.parent;
+  }
+  return fullyQualifiedTypeName;
+}
+
+export const wrapperTypes = new Set([
+  '.google.protobuf.DoubleValue',
+  '.google.protobuf.FloatValue',
+  '.google.protobuf.Int64Value',
+  '.google.protobuf.UInt64Value',
+  '.google.protobuf.Int32Value',
+  '.google.protobuf.UInt32Value',
+  '.google.protobuf.BoolValue',
+  '.google.protobuf.StringValue',
+  '.google.protobuf.BytesValue',
+]);

--- a/typescript/src/value.ts
+++ b/typescript/src/value.ts
@@ -1,0 +1,165 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import {FromObjectValue, JSONObject, JSONValue} from './types';
+
+export interface Struct {
+  fields: {
+    [key: string]: Value;
+  };
+}
+
+export interface ListValue {
+  values: Array<Value>;
+}
+
+export interface Value {
+  nullValue?: 0;
+  numberValue?: number;
+  stringValue?: string;
+  boolValue?: boolean;
+  listValue?: ListValue;
+  structValue?: Struct;
+}
+
+export function googleProtobufStructToProto3JSON(
+  obj: protobuf.Message & Struct
+) {
+  const result: JSONObject = {};
+  const fields = obj.fields;
+  for (const [key, value] of Object.entries(fields)) {
+    result[key] = googleProtobufValueToProto3JSON(
+      value as protobuf.Message & Value
+    );
+  }
+  return result;
+}
+
+export function googleProtobufListValueToProto3JSON(
+  obj: protobuf.Message & ListValue
+) {
+  assert(
+    Array.isArray(obj.values),
+    'ListValue internal representation must contain array of values'
+  );
+  return (obj.values as Array<protobuf.Message & Value>).map(
+    googleProtobufValueToProto3JSON
+  );
+}
+
+export function googleProtobufValueToProto3JSON(
+  obj: protobuf.Message & Value
+): JSONValue {
+  if (Object.prototype.hasOwnProperty.call(obj, 'nullValue')) {
+    return null;
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(obj, 'numberValue') &&
+    typeof obj.numberValue === 'number'
+  ) {
+    return obj.numberValue;
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(obj, 'stringValue') &&
+    typeof obj.stringValue === 'string'
+  ) {
+    return obj.stringValue;
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(obj, 'boolValue') &&
+    typeof obj.boolValue === 'boolean'
+  ) {
+    return obj.boolValue;
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(obj, 'structValue') &&
+    typeof obj.structValue === 'object'
+  ) {
+    return googleProtobufStructToProto3JSON(
+      obj.structValue as protobuf.Message & Struct
+    );
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(obj, 'listValue') &&
+    typeof obj === 'object' &&
+    typeof obj.listValue === 'object'
+  ) {
+    return googleProtobufListValueToProto3JSON(
+      obj.listValue as protobuf.Message & ListValue
+    );
+  }
+
+  // Assuming empty Value to be null
+  return null;
+}
+
+export function googleProtobufStructFromProto3JSON(
+  json: JSONObject
+): FromObjectValue {
+  const fields: FromObjectValue = {};
+  for (const [key, value] of Object.entries(json)) {
+    fields[key] = googleProtobufValueFromProto3JSON(value);
+  }
+  return {fields};
+}
+
+export function googleProtobufListValueFromProto3JSON(
+  json: JSONValue[]
+): FromObjectValue {
+  return {
+    values: json.map(element => googleProtobufValueFromProto3JSON(element)),
+  };
+}
+
+export function googleProtobufValueFromProto3JSON(
+  json: JSONValue
+): FromObjectValue {
+  if (json === null) {
+    return {nullValue: 'NULL_VALUE'};
+  }
+
+  if (typeof json === 'number') {
+    return {numberValue: json};
+  }
+
+  if (typeof json === 'string') {
+    return {stringValue: json};
+  }
+
+  if (typeof json === 'boolean') {
+    return {boolValue: json};
+  }
+
+  if (Array.isArray(json)) {
+    return {
+      listValue: googleProtobufListValueFromProto3JSON(json),
+    };
+  }
+
+  if (typeof json === 'object') {
+    return {
+      structValue: googleProtobufStructFromProto3JSON(json),
+    };
+  }
+
+  throw new Error(
+    `googleProtobufValueFromProto3JSON: incorrect parameter type: ${typeof json}`
+  );
+}

--- a/typescript/src/wrappers.ts
+++ b/typescript/src/wrappers.ts
@@ -1,0 +1,76 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import {bytesFromProto3JSON, bytesToProto3JSON} from './bytes';
+import {LongStub} from './types';
+
+export interface NumberValue {
+  value: number | object; // Long can be passed here
+}
+
+export interface StringValue {
+  value: string;
+}
+
+export interface BoolValue {
+  value: boolean;
+}
+
+export interface BytesValue {
+  value: Buffer | Uint8Array;
+}
+
+export function wrapperToProto3JSON(
+  obj: protobuf.Message & (NumberValue | StringValue | BoolValue | BytesValue)
+) {
+  if (!Object.prototype.hasOwnProperty.call(obj, 'value')) {
+    return null;
+  }
+  if (Buffer.isBuffer(obj.value) || obj.value instanceof Uint8Array) {
+    return bytesToProto3JSON(obj.value);
+  }
+  if (typeof obj.value === 'object') {
+    assert(
+      obj.value.constructor.name === 'Long',
+      `wrapperToProto3JSON: expected to see a number, a string, a boolean, or a Long, but got ${obj.value}`
+    );
+    return (obj.value as LongStub).toNumber();
+  }
+  return obj.value;
+}
+
+export function wrapperFromProto3JSON(
+  typeName: string,
+  json: number | string | boolean | null
+) {
+  if (json === null) {
+    return {
+      value: null,
+    };
+  }
+  if (typeName === '.google.protobuf.BytesValue') {
+    if (typeof json !== 'string') {
+      throw new Error(
+        `numberWrapperFromProto3JSON: expected to get a string for google.protobuf.BytesValue but got ${typeof json}`
+      );
+    }
+    return {
+      value: bytesFromProto3JSON(json),
+    };
+  }
+  return {
+    value: json,
+  };
+}

--- a/typescript/test/system/install.ts
+++ b/typescript/test/system/install.ts
@@ -1,0 +1,58 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {packNTest} from 'pack-n-play';
+import {describe, it} from 'mocha';
+
+describe('Packing test', () => {
+  it('should work in TypeScript code', async function () {
+    this.timeout(300000);
+    const options = {
+      packageDir: process.cwd(),
+      sample: {
+        description: 'runs serializer and deserializer in TypeScript',
+        ts: `
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import * as serializer from 'proto3-json-serializer';
+const root = protobuf.Root.fromJSON({
+  "nested": {
+    "Test": {
+      "fields": {
+        "field": {
+          "type": "string",
+          "id": 1
+        }
+      }
+    }
+  }
+});
+const Test = root.lookupType('Test');
+const json = {
+  field: 'test',
+};
+const message = serializer.fromProto3JSON(Test, json);
+assert(message);
+const serialized = serializer.toProto3JSON(message);
+assert.deepStrictEqual(serialized, json);
+`,
+        dependencies: ['protobufjs@^6.11.2'],
+      },
+    };
+    await packNTest(options).catch(err => {
+      console.error(err);
+      throw err;
+    });
+  });
+});

--- a/typescript/test/unit/any.ts
+++ b/typescript/test/unit/any.ts
@@ -1,0 +1,85 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+
+function testRegularAny(root: protobuf.Root) {
+  const MessageWithAny = root.lookupType('test.MessageWithAny');
+  const AnyContent = root.lookupType('test.AnyContent');
+  const any = AnyContent.fromObject({
+    stringField: 'string',
+  });
+  const message = MessageWithAny.fromObject({
+    anyField: {
+      type_url: 'types.googleapis.com/test.AnyContent', // note: snake case here because of protobuf.js bug/feature
+      value: Buffer.from(AnyContent.encode(any).finish()),
+    },
+  });
+  const json = {
+    anyField: {
+      '@type': 'types.googleapis.com/test.AnyContent',
+      stringField: 'string',
+    },
+  };
+
+  it('serializes to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithAny, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
+function testAnyWithSpecialType(root: protobuf.Root) {
+  const MessageWithAny = root.lookupType('test.MessageWithAny');
+  const Value = root.lookupType('google.protobuf.Value');
+  const value = Value.fromObject({
+    stringValue: 'test',
+  });
+  const message = MessageWithAny.fromObject({
+    anyField: {
+      type_url: 'types.googleapis.com/google.protobuf.Value',
+      value: Buffer.from(Value.encode(value).finish()),
+    },
+  });
+  const json = {
+    anyField: {
+      '@type': 'types.googleapis.com/google.protobuf.Value',
+      value: 'test',
+    },
+  };
+
+  it('serializes google.protobuf.Any with a special type to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes google.protobuf.Any with a special type from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithAny, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
+testTwoTypesOfLoad('google.protobuf.Any', [
+  testRegularAny,
+  testAnyWithSpecialType,
+]);

--- a/typescript/test/unit/bytes.ts
+++ b/typescript/test/unit/bytes.ts
@@ -1,0 +1,52 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+
+function testBytes(root: protobuf.Root) {
+  const MessageWithBytesField = root.lookupType('test.MessageWithBytesField');
+  const buffer = Buffer.from('buffer');
+  const message = MessageWithBytesField.fromObject({
+    bytesField: buffer,
+  });
+  const uint8Array = new Uint8Array(buffer, 0, buffer.length);
+  const messageWithUint8Array = MessageWithBytesField.fromObject({
+    bytesField: uint8Array,
+  });
+  const json = {
+    bytesField: buffer.toString('base64'),
+  };
+
+  it('serializes bytes as Buffer to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('serializes bytes as Uint8Array to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageWithUint8Array);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithBytesField, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
+testTwoTypesOfLoad('bytes', testBytes);

--- a/typescript/test/unit/common.ts
+++ b/typescript/test/unit/common.ts
@@ -1,0 +1,50 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as path from 'path';
+import * as protobuf from 'protobufjs';
+import {describe} from 'mocha';
+
+const fixtures = path.join(__dirname, '..', '..', '..', 'test-fixtures');
+
+interface TestFunction {
+  (root: protobuf.Root): void;
+}
+
+export function testTwoTypesOfLoad(
+  name: string,
+  testFunctions: TestFunction | Array<TestFunction>
+) {
+  const functions: Array<TestFunction> = Array.isArray(testFunctions)
+    ? testFunctions
+    : [testFunctions];
+  describe(name, () => {
+    describe('loadSync test', () => {
+      const root = protobuf.loadSync(
+        path.join(fixtures, 'proto', 'test.proto')
+      );
+      functions.map(func => {
+        func(root);
+      });
+    });
+    describe('fromJSON test', () => {
+      const root = protobuf.Root.fromJSON(
+        require(path.join(fixtures, 'proto', 'test.json'))
+      );
+      functions.map(func => {
+        func(root);
+      });
+    });
+  });
+}

--- a/typescript/test/unit/duration.ts
+++ b/typescript/test/unit/duration.ts
@@ -1,0 +1,64 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+
+function testDuration(root: protobuf.Root) {
+  const MessageWithDuration = root.lookupType('test.MessageWithDuration');
+  // note the zero padding according to the spec:
+  // the number of the digits in the fractional part must be 0, 3, 6, or 9
+  const testMapping = [
+    {duration: {seconds: 3}, value: '3s'},
+    {duration: {nanos: 100000000}, value: '0.100s'},
+    {duration: {}, value: '0s'},
+    {duration: {seconds: 3, nanos: 5}, value: '3.000000005s'},
+    {duration: {seconds: 3, nanos: 5000}, value: '3.000005s'},
+    {duration: {seconds: 3, nanos: 5000000}, value: '3.005s'},
+    {duration: {nanos: 1}, value: '0.000000001s'},
+    {duration: {nanos: 10}, value: '0.000000010s'},
+    {duration: {nanos: 100}, value: '0.000000100s'},
+    {duration: {nanos: 1000}, value: '0.000001s'},
+    {duration: {nanos: 10000}, value: '0.000010s'},
+    {duration: {nanos: 100000}, value: '0.000100s'},
+    {duration: {nanos: 1000000}, value: '0.001s'},
+    {duration: {nanos: 10000000}, value: '0.010s'},
+    {duration: {nanos: 100000000}, value: '0.100s'},
+  ];
+
+  for (const mapping of testMapping) {
+    const message = MessageWithDuration.fromObject({
+      durationField: mapping.duration,
+    });
+    const json = {
+      durationField: mapping.value,
+    };
+
+    it(`serializes ${JSON.stringify(mapping.duration)} to proto3 JSON`, () => {
+      const serialized = toProto3JSON(message);
+      assert.deepStrictEqual(serialized, json);
+    });
+
+    it(`deserializes "${mapping.value}" from proto3 JSON`, () => {
+      const deserialized = fromProto3JSON(MessageWithDuration, json);
+      assert.deepStrictEqual(deserialized, message);
+    });
+  }
+}
+
+testTwoTypesOfLoad('google.protobuf.Duration', testDuration);

--- a/typescript/test/unit/empty.ts
+++ b/typescript/test/unit/empty.ts
@@ -1,0 +1,42 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+
+function testEmpty(root: protobuf.Root) {
+  const MessageWithEmpty = root.lookupType('test.MessageWithEmpty');
+  const message = MessageWithEmpty.fromObject({
+    emptyField: {},
+  });
+  const json = {
+    emptyField: {},
+  };
+
+  it('serializes to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithEmpty, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
+testTwoTypesOfLoad('google.protobuf.Empty', testEmpty);

--- a/typescript/test/unit/enum.ts
+++ b/typescript/test/unit/enum.ts
@@ -1,0 +1,42 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+
+function testEnum(root: protobuf.Root) {
+  const MessageWithEnum = root.lookupType('test.MessageWithEnum');
+  const message = MessageWithEnum.fromObject({
+    enumField: 'KNOWN',
+  });
+  const json = {
+    enumField: 'KNOWN',
+  };
+
+  it('serializes to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithEnum, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
+testTwoTypesOfLoad('enum field', testEnum);

--- a/typescript/test/unit/error-coverage.ts
+++ b/typescript/test/unit/error-coverage.ts
@@ -1,0 +1,285 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+import {JSONValue} from '../../src';
+
+function testAnyErrorCoverage(root: protobuf.Root) {
+  const Any = root.lookupType('google.protobuf.Any');
+  const message = Any.create({
+    type_url: 'types.googleapis.com/UnknownType',
+    value: Buffer.from(''),
+  });
+  const json = {
+    '@type': 'types.googleapis.com/UnknownType',
+    stringField: 'string',
+  };
+  const noTypeUrlJson = {
+    stringField: 'string',
+  };
+  const incorrectSpecialValueJson = {
+    '@type': 'types.googleapis.com/google.protobuf.Value',
+    stringField: 'string',
+  };
+
+  it('Any catches unknown type when deserializing', () => {
+    assert.throws(() => {
+      fromProto3JSON(Any, json);
+    });
+  });
+
+  it('Any catches unknown type when serializing', () => {
+    assert.throws(() => {
+      toProto3JSON(message);
+    });
+  });
+
+  it('Any requires @type field when deserializing', () => {
+    assert.throws(() => {
+      fromProto3JSON(Any, noTypeUrlJson);
+    });
+  });
+
+  it('Any does not accept incorrect special JSON', () => {
+    assert.throws(() => {
+      fromProto3JSON(Any, incorrectSpecialValueJson);
+    });
+  });
+}
+
+function testTypeMismatch(root: protobuf.Root) {
+  const PrimitiveTypes = root.lookupType('test.PrimitiveTypes');
+  const MessageWithBytesField = root.lookupType('test.MessageWithBytesField');
+  const MessageWithRepeated = root.lookupType('test.MessageWithRepeated');
+  const MessageWithAny = root.lookupType('test.MessageWithAny');
+  const MessageWithEnum = root.lookupType('test.MessageWithEnum');
+  const MessageWithStruct = root.lookupType('test.MessageWithStruct');
+  const MessageWithValue = root.lookupType('test.MessageWithValue');
+  const MessageWithListValue = root.lookupType('test.MessageWithListValue');
+  const MessageWithDuration = root.lookupType('test.MessageWithDuration');
+  const MessageWithTimestamp = root.lookupType('test.MessageWithTimestamp');
+  const MessageWithWrappers = root.lookupType('test.MessageWithWrappers');
+  const MessageWithFieldMask = root.lookupType('test.MessageWithFieldMask');
+
+  it('fromProto3JSON catches wrong value for integer fields', () => {
+    assert.throws(() => {
+      fromProto3JSON(PrimitiveTypes, {integerField: '42'});
+    });
+  });
+
+  it('fromProto3JSON catches wrong value for string fields', () => {
+    assert.throws(() => {
+      fromProto3JSON(PrimitiveTypes, {stringField: 42});
+    });
+  });
+
+  it('fromProto3JSON catches wrong value for bool fields', () => {
+    assert.throws(() => {
+      fromProto3JSON(PrimitiveTypes, {boolField: 'true'});
+    });
+  });
+
+  it('fromProto3JSON catches wrong value for bytes fields', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithBytesField, {bytesField: 1234});
+    });
+  });
+
+  it('fromProto3JSON requires an array for repeated fields', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithRepeated, {repeatedString: 'test'});
+    });
+  });
+
+  it('fromProto3JSON requires Any to be an object', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithAny, {anyField: 'zzz'});
+    });
+  });
+
+  it('fromProto3JSON requires enum to be a string or a number', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithEnum, {enumField: {}});
+    });
+  });
+
+  it('fromProto3JSON does not allow unknown enum string value', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithEnum, {enumField: 'WRONG VALUE'});
+    });
+  });
+
+  it('fromProto3JSON does not allow unknown enum number value', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithEnum, {enumField: 42});
+    });
+  });
+
+  it('fromProto3JSON does not allow primitive types for Struct values', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithStruct, {structField: 42});
+    });
+  });
+
+  it('fromProto3JSON does not allow arrays for Struct values', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithStruct, {structField: [41, 42]});
+    });
+  });
+
+  it('fromProto3JSON does not allow objects for ListValue values', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithListValue, {listValueField: {}});
+    });
+  });
+
+  it('fromProto3JSON does not allow non-JSON types', () => {
+    const func = () => {};
+    // calling it just for coverage :)
+    func();
+    assert.throws(() => {
+      fromProto3JSON(MessageWithValue, {
+        valueField: func,
+      } as unknown as JSONValue);
+    });
+  });
+
+  it('fromProto3JSON does not allow non-string types for google.protobuf.Duration', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithDuration, {
+        durationField: {seconds: 3, nanos: 0},
+      });
+    });
+  });
+
+  it('fromProto3JSON does not allow incorrect strings for google.protobuf.Duration', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithDuration, {
+        durationField: '12345',
+      });
+    });
+  });
+
+  it('fromProto3JSON does not allow non-string types for google.protobuf.Timestamp', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithTimestamp, {
+        timestampField: {seconds: 3, nanos: 0},
+      });
+    });
+  });
+
+  it('fromProto3JSON does not allow incorrect strings for google.protobuf.Timestamp', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithTimestamp, {
+        timestampField: '12345',
+      });
+    });
+  });
+
+  it('fromProto3JSON does not allow object for wrapper types', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithWrappers, {
+        doubleValueField: {},
+      });
+    });
+  });
+
+  it('fromProto3JSON does not allow non-strings for BytesValue', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithWrappers, {
+        bytesValueField: 42,
+      });
+    });
+  });
+
+  it('fromProto3JSON does not allow non-strings for FieldMask', () => {
+    assert.throws(() => {
+      fromProto3JSON(MessageWithFieldMask, {
+        fieldMaskField: 42,
+      });
+    });
+  });
+}
+
+function testNull(root: protobuf.Root) {
+  const PrimitiveTypes = root.lookupType('test.PrimitiveTypes');
+  const MessageWithValue = root.lookupType('test.MessageWithValue');
+  const MessageWithAny = root.lookupType('test.MessageWithAny');
+
+  it('fromProto3JSON returns null for null input', () => {
+    assert.strictEqual(fromProto3JSON(PrimitiveTypes, null), null);
+  });
+
+  it('toProto3JSON returns null for empty Value', () => {
+    const emptyValue = MessageWithValue.fromObject({
+      valueField: {},
+    });
+    const emptyValueJson = {
+      valueField: null,
+    };
+    assert.deepStrictEqual(toProto3JSON(emptyValue), emptyValueJson);
+  });
+
+  it('fromProto3JSON returns null for empty google.protobuf.Any', () => {
+    const emptyAny = MessageWithAny.fromObject({});
+    const emptyAnyJson = {
+      anyField: null,
+    };
+    assert.deepStrictEqual(
+      fromProto3JSON(MessageWithAny, emptyAnyJson),
+      emptyAny
+    );
+  });
+
+  it('fromProto3JSON returns null for google.protobuf.Any with null value', () => {
+    const nullAny = MessageWithAny.fromObject({
+      anyField: {
+        type_url: 'types.googleapis.com/google.protobuf.Struct',
+        value: null,
+      },
+    });
+    const nullAnyJson = {
+      anyField: {
+        '@type': 'types.googleapis.com/google.protobuf.Struct',
+        value: null,
+      },
+    };
+    assert.deepStrictEqual(
+      fromProto3JSON(MessageWithAny, nullAnyJson),
+      nullAny
+    );
+  });
+}
+
+function testRegularObject() {
+  it('toProto3JSON does not accept non-Message object', () => {
+    assert.throws(() => {
+      toProto3JSON({
+        stringField: 'test',
+      } as unknown as protobuf.Message);
+    });
+  });
+}
+
+testTwoTypesOfLoad('error coverage', [
+  testAnyErrorCoverage,
+  testTypeMismatch,
+  testNull,
+  testRegularObject,
+]);

--- a/typescript/test/unit/fieldmask.ts
+++ b/typescript/test/unit/fieldmask.ts
@@ -1,0 +1,45 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+
+function testFieldMask(root: protobuf.Root) {
+  const MessageWithFieldMask = root.lookupType('test.MessageWithFieldMask');
+
+  const message = MessageWithFieldMask.fromObject({
+    fieldMaskField: {
+      paths: ['a.b', 'c.d.e'],
+    },
+  });
+  const json = {
+    fieldMaskField: 'a.b,c.d.e',
+  };
+
+  it('serializes to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithFieldMask, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
+testTwoTypesOfLoad('google.protobuf.Timestamp', testFieldMask);

--- a/typescript/test/unit/map.ts
+++ b/typescript/test/unit/map.ts
@@ -1,0 +1,64 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+
+function testMap(root: protobuf.Root) {
+  const MessageWithMap = root.lookupType('test.MessageWithMap');
+  const message = MessageWithMap.fromObject({
+    mapField: {
+      key1: {
+        stringField: 'value1',
+      },
+      key2: {
+        stringField: 'value2',
+      },
+    },
+    stringMapField: {
+      key1: 'string value 1',
+      key2: 'string value 2',
+    },
+  });
+  const json = {
+    mapField: {
+      key1: {
+        stringField: 'value1',
+      },
+      key2: {
+        stringField: 'value2',
+      },
+    },
+    stringMapField: {
+      key1: 'string value 1',
+      key2: 'string value 2',
+    },
+  };
+
+  it('serializes to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithMap, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
+testTwoTypesOfLoad('map fields', testMap);

--- a/typescript/test/unit/nested.ts
+++ b/typescript/test/unit/nested.ts
@@ -1,0 +1,72 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+import {JSONObject} from '../../src';
+
+function testNestedMessage(root: protobuf.Root) {
+  const MessageWithNestedMessage = root.lookupType(
+    'test.MessageWithNestedMessage'
+  );
+  const message = MessageWithNestedMessage.fromObject({
+    innerMessage: {
+      stringField: 'test',
+    },
+  });
+  const json = {
+    innerMessage: {
+      stringField: 'test',
+    },
+  };
+
+  const emptyMessage = MessageWithNestedMessage.fromObject({});
+  const messageWithNull = MessageWithNestedMessage.fromObject({});
+  (messageWithNull as unknown as JSONObject)['innerMessage'] = null;
+  const jsonWithNull = {
+    innerMessage: null,
+  };
+  const emptyJson = {};
+
+  it('serializes to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithNestedMessage, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+
+  it('serialized empty message results in empty proto3 JSON', () => {
+    const serialized = toProto3JSON(emptyMessage);
+    assert.deepStrictEqual(serialized, emptyJson);
+  });
+
+  it('serialized null inner message results in JSON with null', () => {
+    const serialized = toProto3JSON(messageWithNull);
+    assert.deepStrictEqual(serialized, jsonWithNull);
+  });
+
+  it('deserialized null inner message from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithNestedMessage, jsonWithNull);
+    assert.deepStrictEqual(deserialized, emptyMessage);
+  });
+}
+
+testTwoTypesOfLoad('nested messages', testNestedMessage);

--- a/typescript/test/unit/oneof.ts
+++ b/typescript/test/unit/oneof.ts
@@ -1,0 +1,78 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+
+function testOneof(root: protobuf.Root) {
+  const MessageWithOneof = root.lookupType('test.MessageWithOneof');
+  const message1 = MessageWithOneof.fromObject({
+    stringField: 'test',
+  });
+  const message2 = MessageWithOneof.fromObject({
+    integerField: 42,
+  });
+  const message3 = MessageWithOneof.fromObject({
+    messageField: {
+      stringField: 'test',
+    },
+  });
+  const json1 = {
+    stringField: 'test',
+  };
+  const json2 = {
+    integerField: 42,
+  };
+  const json3 = {
+    messageField: {
+      stringField: 'test',
+    },
+  };
+
+  it('serializes oneof 1 to proto3 JSON', () => {
+    const serialized = toProto3JSON(message1);
+    assert.deepStrictEqual(serialized, json1);
+  });
+
+  it('deserializes oneof 1 from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithOneof, json1);
+    assert.deepStrictEqual(deserialized, message1);
+  });
+
+  it('serializes oneof 2 to proto3 JSON', () => {
+    const serialized = toProto3JSON(message2);
+    assert.deepStrictEqual(serialized, json2);
+  });
+
+  it('deserializes oneof 2 from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithOneof, json2);
+    assert.deepStrictEqual(deserialized, message2);
+  });
+
+  it('serializes oneof 3 to proto3 JSON', () => {
+    const serialized = toProto3JSON(message3);
+    assert.deepStrictEqual(serialized, json3);
+  });
+
+  it('deserializes oneof 3 from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithOneof, json3);
+    assert.deepStrictEqual(deserialized, message3);
+  });
+}
+
+testTwoTypesOfLoad('oneof', testOneof);

--- a/typescript/test/unit/primitive.ts
+++ b/typescript/test/unit/primitive.ts
@@ -1,0 +1,54 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+
+function testPrimitiveTypes(root: protobuf.Root) {
+  const PrimitiveTypes = root.lookupType('test.PrimitiveTypes');
+  const message = PrimitiveTypes.fromObject({
+    integerField: -42,
+    unsignedIntegerField: 42,
+    fixedIntegerField: 128,
+    stringField: 'test',
+    boolField: true,
+    int64Field: -43,
+    uint64Field: 43,
+  });
+  const json = {
+    integerField: -42,
+    unsignedIntegerField: 42,
+    fixedIntegerField: 128,
+    stringField: 'test',
+    boolField: true,
+    int64Field: -43,
+    uint64Field: 43,
+  };
+
+  it('serializes to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(PrimitiveTypes, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
+testTwoTypesOfLoad('primitive types', testPrimitiveTypes);

--- a/typescript/test/unit/repeated.ts
+++ b/typescript/test/unit/repeated.ts
@@ -1,0 +1,58 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+
+function testRepeated(root: protobuf.Root) {
+  const MessageWithRepeated = root.lookupType('test.MessageWithRepeated');
+  const message = MessageWithRepeated.fromObject({
+    repeatedString: ['value1', 'value2', 'value3'],
+    repeatedMessage: [
+      {
+        stringField: 'value1',
+      },
+      {
+        stringField: 'value2',
+      },
+    ],
+  });
+  const json = {
+    repeatedString: ['value1', 'value2', 'value3'],
+    repeatedMessage: [
+      {
+        stringField: 'value1',
+      },
+      {
+        stringField: 'value2',
+      },
+    ],
+  };
+
+  it('serializes to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithRepeated, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
+testTwoTypesOfLoad('repeated fields', testRepeated);

--- a/typescript/test/unit/timestamp.ts
+++ b/typescript/test/unit/timestamp.ts
@@ -1,0 +1,54 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+
+function testTimestamp(root: protobuf.Root) {
+  const MessageWithTimestamp = root.lookupType('test.MessageWithTimestamp');
+  const testMapping = [
+    // example from google/protobuf/timestamp.proto
+    {
+      timestamp: {seconds: 1484443815, nanos: 10000000},
+      value: '2017-01-15T01:30:15.010Z',
+    },
+    {timestamp: {nanos: 10000000}, value: '1970-01-01T00:00:00.010Z'},
+    {timestamp: {seconds: 1484443815}, value: '2017-01-15T01:30:15.000Z'},
+  ];
+
+  for (const mapping of testMapping) {
+    const message = MessageWithTimestamp.fromObject({
+      timestampField: mapping.timestamp,
+    });
+    const json = {
+      timestampField: mapping.value,
+    };
+
+    it(`serializes ${JSON.stringify(mapping.timestamp)} to proto3 JSON`, () => {
+      const serialized = toProto3JSON(message);
+      assert.deepStrictEqual(serialized, json);
+    });
+
+    it(`deserializes "${mapping.value}" from proto3 JSON`, () => {
+      const deserialized = fromProto3JSON(MessageWithTimestamp, json);
+      assert.deepStrictEqual(deserialized, message);
+    });
+  }
+}
+
+testTwoTypesOfLoad('google.protobuf.Timestamp', testTimestamp);

--- a/typescript/test/unit/value.ts
+++ b/typescript/test/unit/value.ts
@@ -1,0 +1,317 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+import {JSONObject} from '../../src';
+
+function testGoogleProtobufValue(root: protobuf.Root) {
+  const MessageWithValue = root.lookupType('test.MessageWithValue');
+  const messageNull = MessageWithValue.fromObject({
+    valueField: {
+      nullValue: 'NULL_VALUE',
+    },
+  });
+  const jsonNull = {valueField: null};
+  const messageNumber = MessageWithValue.fromObject({
+    valueField: {
+      numberValue: 42,
+    },
+  });
+  const jsonNumber = {valueField: 42};
+  const messageString = MessageWithValue.fromObject({
+    valueField: {
+      stringValue: 'test',
+    },
+  });
+  const jsonString = {valueField: 'test'};
+  const messageBool = MessageWithValue.fromObject({
+    valueField: {
+      boolValue: true,
+    },
+  });
+  const jsonBool = {valueField: true};
+  const messageStruct = MessageWithValue.fromObject({
+    valueField: {
+      structValue: {
+        fields: {
+          nestedNull: (messageNull as unknown as JSONObject).valueField,
+          nestedNumber: (messageNumber as unknown as JSONObject).valueField,
+          nestedString: (messageString as unknown as JSONObject).valueField,
+          nestedBool: (messageBool as unknown as JSONObject).valueField,
+          nestedStruct: {
+            structValue: {
+              fields: {
+                stringField: {
+                  stringValue: 'test',
+                },
+              },
+            },
+          },
+          nestedList: {
+            listValue: {
+              values: [
+                {
+                  stringValue: 'test',
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  });
+  const jsonStruct = {
+    valueField: {
+      nestedNull: jsonNull.valueField,
+      nestedNumber: jsonNumber.valueField,
+      nestedString: jsonString.valueField,
+      nestedBool: jsonBool.valueField,
+      nestedStruct: {
+        stringField: 'test',
+      },
+      nestedList: ['test'],
+    },
+  };
+  const messageList = MessageWithValue.fromObject({
+    valueField: {
+      listValue: {
+        values: [
+          (messageNull as unknown as JSONObject).valueField,
+          (messageNumber as unknown as JSONObject).valueField,
+          (messageString as unknown as JSONObject).valueField,
+          (messageBool as unknown as JSONObject).valueField,
+          (messageStruct as unknown as JSONObject).valueField,
+          {
+            listValue: {
+              values: [
+                {
+                  stringValue: 'test',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  });
+  const jsonList = {
+    valueField: [
+      jsonNull.valueField,
+      jsonNumber.valueField,
+      jsonString.valueField,
+      jsonBool.valueField,
+      jsonStruct.valueField,
+      ['test'],
+    ],
+  };
+
+  it('serializes NullValue to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageNull);
+    assert.deepStrictEqual(serialized, jsonNull);
+  });
+
+  it('deserializes NullValue from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithValue, jsonNull);
+    assert.deepStrictEqual(deserialized, messageNull);
+  });
+
+  it('serializes NumberValue to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageNumber);
+    assert.deepStrictEqual(serialized, jsonNumber);
+  });
+
+  it('deserializes NumberValue from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithValue, jsonNumber);
+    assert.deepStrictEqual(deserialized, messageNumber);
+  });
+
+  it('serializes StringValue to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageString);
+    assert.deepStrictEqual(serialized, jsonString);
+  });
+
+  it('deserializes StringValue from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithValue, jsonString);
+    assert.deepStrictEqual(deserialized, messageString);
+  });
+
+  it('serializes BoolValue to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageBool);
+    assert.deepStrictEqual(serialized, jsonBool);
+  });
+
+  it('deserializes BoolValue from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithValue, jsonBool);
+    assert.deepStrictEqual(deserialized, messageBool);
+  });
+
+  it('serializes StructValue to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageStruct);
+    assert.deepStrictEqual(serialized, jsonStruct);
+  });
+
+  it('deserializes StructValue from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithValue, jsonStruct);
+    assert.deepStrictEqual(deserialized, messageStruct);
+  });
+
+  it('serializes ListValue to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageList);
+    assert.deepStrictEqual(serialized, jsonList);
+  });
+
+  it('deserializes ListValue from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithValue, jsonList);
+    assert.deepStrictEqual(deserialized, messageList);
+  });
+}
+
+function testGoogleProtobufStruct(root: protobuf.Root) {
+  const MessageWithStruct = root.lookupType('test.MessageWithStruct');
+  const message = MessageWithStruct.fromObject({
+    structField: {
+      fields: {
+        stringField: {
+          stringValue: 'test',
+        },
+        numberField: {
+          numberValue: 42,
+        },
+      },
+    },
+  });
+  const json = {
+    structField: {
+      stringField: 'test',
+      numberField: 42,
+    },
+  };
+
+  const emptyStructMessage = MessageWithStruct.fromObject({
+    structField: {},
+  });
+  const emptyStructJson = {
+    structField: {},
+  };
+
+  it('serializes google.protobuf.Struct to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes google.protobuf.Struct from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithStruct, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+
+  it('serializes empty google.protobuf.Struct to proto3 JSON', () => {
+    const serialized = toProto3JSON(emptyStructMessage);
+    assert.deepStrictEqual(serialized, emptyStructJson);
+  });
+
+  it('deserializes empty google.protobuf.Struct from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithStruct, emptyStructJson);
+    assert.deepStrictEqual(deserialized, emptyStructMessage);
+  });
+}
+
+function testGoogleProtobufListValue(root: protobuf.Root) {
+  const MessageWithListValue = root.lookupType('test.MessageWithListValue');
+  const message = MessageWithListValue.fromObject({
+    listValueField: {
+      values: [
+        {
+          structValue: {
+            fields: {
+              stringField: {
+                stringValue: 'test',
+              },
+            },
+          },
+        },
+        {
+          structValue: {
+            fields: {
+              numberField: {
+                numberValue: 42,
+              },
+            },
+          },
+        },
+      ],
+    },
+  });
+  const json: JSONObject = {
+    listValueField: [{stringField: 'test'}, {numberField: 42}],
+  };
+
+  const emptyListMessage = MessageWithListValue.fromObject({
+    listValueField: {},
+  });
+  const emptyListJson = {
+    listValueField: [],
+  };
+
+  it('serializes google.protobuf.ListValue to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes google.protobuf.ListValue from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithListValue, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+
+  it('serializes empty google.protobuf.ListValue to proto3 JSON', () => {
+    const serialized = toProto3JSON(emptyListMessage);
+    assert.deepStrictEqual(serialized, emptyListJson);
+  });
+
+  it('deserializes empty google.protobuf.ListValue from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithListValue, emptyListJson);
+    assert.deepStrictEqual(deserialized, emptyListMessage);
+  });
+}
+
+function testGoogleProtobufNullValue(root: protobuf.Root) {
+  const MessageWithNullValue = root.lookupType('test.MessageWithNullValue');
+  const message = MessageWithNullValue.fromObject({
+    nullValueField: 'NULL_VALUE',
+  });
+  const json = {
+    nullValueField: null,
+  };
+
+  it('serializes google.protobuf.NullValue to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes google.protobuf.NullValue from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithNullValue, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
+testTwoTypesOfLoad('google.protobuf.Value', [
+  testGoogleProtobufValue,
+  testGoogleProtobufStruct,
+  testGoogleProtobufListValue,
+  testGoogleProtobufNullValue,
+]);

--- a/typescript/test/unit/wrappers.ts
+++ b/typescript/test/unit/wrappers.ts
@@ -1,0 +1,92 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
+import {it} from 'mocha';
+import {fromProto3JSON} from '../../src/fromproto3json';
+import {toProto3JSON} from '../../src/toproto3json';
+import {testTwoTypesOfLoad} from './common';
+
+function testWrapperTypes(root: protobuf.Root) {
+  const MessageWithWrappers = root.lookupType('test.MessageWithWrappers');
+  const buffer = Buffer.from('buffer');
+  const message = MessageWithWrappers.fromObject({
+    doubleValueField: {value: 3.14},
+    floatValueField: {value: 3.14},
+    int64ValueField: {value: -42},
+    uint64ValueField: {value: 42},
+    int32ValueField: {value: -43},
+    uint32ValueField: {value: 43},
+    boolValueField: {value: true},
+    stringValueField: {value: 'test'},
+    bytesValueField: {value: buffer},
+  });
+  const json = {
+    doubleValueField: 3.14,
+    floatValueField: 3.14,
+    int64ValueField: -42,
+    uint64ValueField: 42,
+    int32ValueField: -43,
+    uint32ValueField: 43,
+    boolValueField: true,
+    stringValueField: 'test',
+    bytesValueField: buffer.toString('base64'),
+  };
+
+  const messageWithNulls = MessageWithWrappers.fromObject({
+    doubleValueField: {},
+    floatValueField: {},
+    int64ValueField: {},
+    uint64ValueField: {},
+    int32ValueField: {},
+    uint32ValueField: {},
+    boolValueField: {},
+    stringValueField: {},
+    bytesValueField: {},
+  });
+  const jsonWithNulls = {
+    doubleValueField: null,
+    floatValueField: null,
+    int64ValueField: null,
+    uint64ValueField: null,
+    int32ValueField: null,
+    uint32ValueField: null,
+    boolValueField: null,
+    stringValueField: null,
+    bytesValueField: null,
+  };
+
+  it('serializes to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithWrappers, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+
+  it('serializes nulls to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageWithNulls);
+    assert.deepStrictEqual(serialized, jsonWithNulls);
+  });
+
+  it('deserializes nulls from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithWrappers, jsonWithNulls);
+    assert.deepStrictEqual(deserialized, messageWithNulls);
+  });
+}
+
+testTwoTypesOfLoad('wrapper types', testWrapperTypes);


### PR DESCRIPTION
And this is the real code to be reviewed. 

The implementation is in `typescript/src`, tests are in `typescript/test`. The implementation of both the serializer and the deserializer is basically recursive, it's the regular traversing of the tree (the JSON tree for the deserializer, and the protobuf object for the serializer), and then I just have a separate pair of functions to serialize/deserialize any proto3 type that has a special JSON representation according to the spec linked below.

`README.md` describes the idea and has all the samples :)  I'll just copy the main part of it here.

# proto3 JSON serializer for TypeScript / JavaScript

This library implements proto3 JSON serialization and deserialization for [protobuf.js](https://www.npmjs.com/package/protobufjs) protobuf objects according to the [spec](https://developers.google.com/protocol-buffers/docs/proto3#json).

Note that the spec requires special representation of some `google.protobuf.*` types (`Value`, `Struct`, `Timestamp`, `Duration`, etc.), so you cannot just use `.toObject()` since the result won't be understood by protobuf in other languages.  Hence this module.

JavaScript:

```js
const serializer = require('proto3-json-serializer');
```

TypeScript:

```ts
import * as serializer from 'proto3-json-serializer';
```

## Serialization: protobuf.js object to proto3 JSON

```js
const root = protobuf.loadSync('test.proto');
const Type = root.lookupType('test.Message');
const message = Type.fromObject({...});

const serialized = serializer.toProto3JSON(message);
```

Serialization works with any object created by calling `.create()`, `.decode()`, or `.fromObject()` for a loaded protobuf type. It relies on the `$type` field so it will not work with a static object.

## Deserialization: proto3 JSON to protobuf.js object

To deserialize an object from proto3 JSON, we must know its type (as returned by `root.lookupType('...')`). Pass this type as the first parameter to `.fromProto3JSON`:

```js
const root = protobuf.loadSync('test.proto');
const Type = root.lookupType('test.Message');
const json = {...};

const deserialized = serializer.fromProto3JSON(Type, json);
```

## Complete example
```js
const assert = require('assert');
const path = require('path');
const protobuf = require('protobufjs');
const serializer = require('proto3-json-serializer');

// We'll take sample protos from google-proto-files but the code will work with any protos
const protos = require('google-proto-files');

// Load some proto file
const rpcProtos = protos.getProtoPath('rpc');
const root = protobuf.loadSync([
    path.join(rpcProtos, 'status.proto'),
    path.join(rpcProtos, 'error_details.proto'),
]);
const Status = root.lookupType('google.rpc.Status');

// If you have a protobuf object that follows proto3 JSON syntax
// https://developers.google.com/protocol-buffers/docs/proto3#json
// (this is an example of google.rpc.Status message in JSON)
const json = {
    code: 3,
    message: 'Test error message',
    details: [
        {
            '@type': 'google.rpc.BadRequest',
            fieldViolations: [
                {
                    field: 'field',
                    description: 'must not be null',
                },
            ],
        },
    ],
};

// You can deserialize it into a protobuf.js object:
const deserialized = serializer.fromProto3JSON(Status, json);
console.log(deserialized);

// And serialize it back
const serialized = serializer.toProto3JSON(deserialized);
assert.deepStrictEqual(serialized, json);
```
