### PR TITLE
fix: accept and return strings for int64 and uint64

### DIFF
--- a/typescript/src/fromproto3json.ts
+++ b/typescript/src/fromproto3json.ts
@@ -163,7 +163,7 @@ export function fromProto3JSONToInternalRepresentation(
     } else if (
       fieldType.match(/^(?:(?:(?:u?int|fixed)(?:32|64))|float|double)$/)
     ) {
-      if (typeof value !== 'number') {
+      if (typeof value !== 'number' && typeof value !== 'string') {
         throw new Error(
           `fromProto3JSONToInternalRepresentation: field ${key} of type ${field.type} cannot contain value ${value}`
         );

--- a/typescript/src/toproto3json.ts
+++ b/typescript/src/toproto3json.ts
@@ -160,7 +160,7 @@ export function toProto3JSON(obj: protobuf.Message): JSONValue {
       value.constructor.name === 'Long',
       `toProto3JSON: don't know how to convert field ${key} with value ${value}`
     );
-    result[key] = (value as LongStub).toNumber();
+    result[key] = (value as LongStub).toString();
     continue;
   }
   return result;

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -34,7 +34,7 @@ export type FromObjectValue =
   | Uint8Array
   | {[key: string]: FromObjectValue};
 
-// We don't want to import long here, we only need .toNumber() from it
+// We don't want to import long here, we only need .toString() from it
 export interface LongStub {
-  toNumber: () => number;
+  toString: () => string;
 }

--- a/typescript/src/wrappers.ts
+++ b/typescript/src/wrappers.ts
@@ -46,7 +46,7 @@ export function wrapperToProto3JSON(
       obj.value.constructor.name === 'Long',
       `wrapperToProto3JSON: expected to see a number, a string, a boolean, or a Long, but got ${obj.value}`
     );
-    return (obj.value as LongStub).toNumber();
+    return (obj.value as LongStub).toString();
   }
   return obj.value;
 }

--- a/typescript/test/unit/error-coverage.ts
+++ b/typescript/test/unit/error-coverage.ts
@@ -79,7 +79,7 @@ function testTypeMismatch(root: protobuf.Root) {
 
   it('fromProto3JSON catches wrong value for integer fields', () => {
     assert.throws(() => {
-      fromProto3JSON(PrimitiveTypes, {integerField: '42'});
+      fromProto3JSON(PrimitiveTypes, {integerField: true});
     });
   });
 

--- a/typescript/test/unit/primitive.ts
+++ b/typescript/test/unit/primitive.ts
@@ -36,8 +36,8 @@ function testPrimitiveTypes(root: protobuf.Root) {
     fixedIntegerField: 128,
     stringField: 'test',
     boolField: true,
-    int64Field: -43,
-    uint64Field: 43,
+    int64Field: '-43',
+    uint64Field: '43',
   };
 
   it('serializes to proto3 JSON', () => {
@@ -51,4 +51,26 @@ function testPrimitiveTypes(root: protobuf.Root) {
   });
 }
 
-testTwoTypesOfLoad('primitive types', testPrimitiveTypes);
+function testLongIntegers(root: protobuf.Root) {
+  const PrimitiveTypes = root.lookupType('test.PrimitiveTypes');
+  const message = PrimitiveTypes.fromObject({
+    int64Field: '-5011754511478056813',
+    uint64Field: '5011754511478056813',
+  });
+  const json = {
+    int64Field: '-5011754511478056813',
+    uint64Field: '5011754511478056813',
+  };
+
+  it('serializes uint64 to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes uint64 from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(PrimitiveTypes, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
+testTwoTypesOfLoad('primitive types', [testPrimitiveTypes, testLongIntegers]);

--- a/typescript/test/unit/wrappers.ts
+++ b/typescript/test/unit/wrappers.ts
@@ -36,8 +36,8 @@ function testWrapperTypes(root: protobuf.Root) {
   const json = {
     doubleValueField: 3.14,
     floatValueField: 3.14,
-    int64ValueField: -42,
-    uint64ValueField: 42,
+    int64ValueField: '-42',
+    uint64ValueField: '42',
     int32ValueField: -43,
     uint32ValueField: 43,
     boolValueField: true,


### PR DESCRIPTION
The [spec](https://developers.google.com/protocol-buffers/docs/proto3#json) allows string values for numbers in JSON (because not all `uint64` and `int64` values can be represented in JavaScript, the maximum "safe" integer is 9007199254740991).

In this PR, we accept strings as numbers (as the spec requires), and we dump numbers as strings if they represent `int64` or `uint64` fields (stored internally as `Long` objects).
