### PR TITLE
fix: use imported protobufjs in toproto3json.ts

### DIFF
--- a/typescript/src/toproto3json.ts
+++ b/typescript/src/toproto3json.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as assert from 'assert';
+import * as protobuf from 'protobufjs';
 import {JSONObject, JSONValue, LongStub} from './types';
 import {Any, googleProtobufAnyToProto3JSON} from './any';
 import {bytesToProto3JSON} from './bytes';


### PR DESCRIPTION
## Description
Ran into a couple issues with conflicting types / packages because protobufjs was not being imported locally. 

This meant it was using the global `protobuf` namespace before, when it was referencing [`protobuf.Message`](https://github.com/googleapis/proto3-json-serializer-nodejs/blob/main/typescript/src/toproto3json.ts#L44) in the function signature of `toProto3JSON`.



## Checklist

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/proto3-json-serializer-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
