### PR TITLE
fix: do not fail for unknown enum values

### DIFF
--- a/typescript/src/enum.ts
+++ b/typescript/src/enum.ts
@@ -19,18 +19,19 @@ export function resolveEnumValueToString(
   enumType: protobuf.Enum,
   enumValue: JSONValue
 ) {
+  // for unknown enum values, do not fail and try to do the best we could.
+  // protobuf.js fromObject() will likely ignore unknown values, but at least
+  // we won't fail.
   if (typeof enumValue === 'number') {
     const value = enumType.valuesById[enumValue];
     if (typeof value === 'undefined') {
-      throw new Error(`enumFromProto3JSON: unknown value id ${enumValue}`);
+      // unknown value, cannot convert to string, returning number as is
+      return enumValue;
     }
     return value;
   }
   if (typeof enumValue === 'string') {
-    const id = enumType.values[enumValue];
-    if (typeof id === 'undefined') {
-      throw new Error(`enumFromProto3JSON: unknown value ${enumValue}`);
-    }
+    // for strings, just accept what we got
     return enumValue;
   }
   throw new Error(

--- a/typescript/test/unit/enum.ts
+++ b/typescript/test/unit/enum.ts
@@ -37,6 +37,18 @@ function testEnum(root: protobuf.Root) {
     const deserialized = fromProto3JSON(MessageWithEnum, json);
     assert.deepStrictEqual(deserialized, message);
   });
+
+  it('fromProto3JSON allows unknown enum string value', () => {
+    // the following call should not fail
+    fromProto3JSON(MessageWithEnum, {
+      enumField: 'WRONG VALUE',
+    });
+  });
+
+  it('fromProto3JSON allows unknown enum number value', () => {
+    // the following call should not fail
+    fromProto3JSON(MessageWithEnum, {enumField: 42});
+  });
 }
 
 testTwoTypesOfLoad('enum field', testEnum);

--- a/typescript/test/unit/error-coverage.ts
+++ b/typescript/test/unit/error-coverage.ts
@@ -119,18 +119,6 @@ function testTypeMismatch(root: protobuf.Root) {
     });
   });
 
-  it('fromProto3JSON does not allow unknown enum string value', () => {
-    assert.throws(() => {
-      fromProto3JSON(MessageWithEnum, {enumField: 'WRONG VALUE'});
-    });
-  });
-
-  it('fromProto3JSON does not allow unknown enum number value', () => {
-    assert.throws(() => {
-      fromProto3JSON(MessageWithEnum, {enumField: 42});
-    });
-  });
-
   it('fromProto3JSON does not allow primitive types for Struct values', () => {
     assert.throws(() => {
       fromProto3JSON(MessageWithStruct, {structField: 42});


### PR DESCRIPTION
If `fromProto3JSON` sees an enum with an unknown value, do not fail. `fromObject` will then likely ignore the unknown value, resulting in an effectively unset enum field, which is still better than throwing an exception.