### PR TITLE
fix: do not emit empty lists to JSON

### DIFF
--- a/typescript/src/toproto3json.ts
+++ b/typescript/src/toproto3json.ts
@@ -110,6 +110,10 @@ export function toProto3JSON(obj: protobuf.Message): JSONValue {
       continue;
     }
     if (Array.isArray(value)) {
+      if (value.length === 0) {
+        // ignore repeated fields with no values
+        continue;
+      }
       // if the repeated value has a complex type, convert it to proto3 JSON, otherwise use as is
       result[key] = value.map(
         fieldResolvedType

--- a/typescript/test/unit/repeated.ts
+++ b/typescript/test/unit/repeated.ts
@@ -55,4 +55,24 @@ function testRepeated(root: protobuf.Root) {
   });
 }
 
+function testEmptyRepeated(root: protobuf.Root) {
+  const MessageWithRepeated = root.lookupType('test.MessageWithRepeated');
+  const message = MessageWithRepeated.fromObject({
+    repeatedString: [],
+    repeatedMessage: [],
+  });
+  const json = {};
+
+  it('serializes to proto3 JSON', () => {
+    const serialized = toProto3JSON(message);
+    assert.deepStrictEqual(serialized, json);
+  });
+
+  it('deserializes from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithRepeated, json);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
 testTwoTypesOfLoad('repeated fields', testRepeated);
+testTwoTypesOfLoad('empty repeated fields', testEmptyRepeated);


### PR DESCRIPTION
The [spec](https://developers.google.com/protocol-buffers/docs/proto3#json) allows to omit empty lists (`repeated` fields with no values) when serializing to JSON. It's equally valid to use `[]`, `null`, or omit it, so we'll just omit.