### PR TITLE
fix: JSON accept special string for NaN, Infinity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 .coverage
 .DS_Store
 __pycache__
+.tgz

--- a/test-fixtures/proto/test.json
+++ b/test-fixtures/proto/test.json
@@ -242,6 +242,18 @@
             "bytesValueField": {
               "type": "google.protobuf.BytesValue",
               "id": 9
+            },
+            "nanValueField": {
+              "type": "google.protobuf.DoubleValue",
+              "id": 10
+            },
+            "infinityValueField": {
+              "type": "google.protobuf.DoubleValue",
+              "id": 11
+            },
+            "negativeInfinityValueField": {
+              "type": "google.protobuf.DoubleValue",
+              "id": 12
             }
           }
         },

--- a/test-fixtures/proto/test.json
+++ b/test-fixtures/proto/test.json
@@ -31,6 +31,10 @@
             "uint64Field": {
               "type": "uint64",
               "id": 7
+            },
+            "doubleField": {
+              "type": "double",
+              "id": 8
             }
           }
         },

--- a/test-fixtures/proto/test.proto
+++ b/test-fixtures/proto/test.proto
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
@@ -61,7 +61,7 @@ message MapValue {
 
 message MessageWithRepeated {
     repeated string repeated_string = 3;
-    repeated RepeatedValue repeated_message = 4;    
+    repeated RepeatedValue repeated_message = 4;
 }
 
 message RepeatedValue {
@@ -123,6 +123,9 @@ message MessageWithWrappers {
     google.protobuf.BoolValue bool_value_field = 7;
     google.protobuf.StringValue string_value_field = 8;
     google.protobuf.BytesValue bytes_value_field = 9;
+    google.protobuf.DoubleValue nan_value_field = 10;
+    google.protobuf.DoubleValue infinity_value_field = 11;
+    google.protobuf.DoubleValue negative_infinity_value_field = 12;
 }
 
 message MessageWithFieldMask {

--- a/test-fixtures/proto/test.proto
+++ b/test-fixtures/proto/test.proto
@@ -32,6 +32,7 @@ message PrimitiveTypes {
     bool bool_field = 5;
     int64 int64_field = 6;
     uint64 uint64_field = 7;
+    double double_field = 8;
 }
 
 message MessageWithNestedMessage {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": "typescript",
-    "outDir": "build"
+    "outDir": "build",
+    "lib": ["dom"]
   },
   "include": [
     "typescript/**/*.ts"

--- a/typescript/src/toproto3json.ts
+++ b/typescript/src/toproto3json.ts
@@ -94,8 +94,7 @@ export function toProto3JSON(obj: protobuf.Message): JSONValue {
   if (wrapperTypes.has(typeName)) {
     return wrapperToProto3JSON(
       obj as protobuf.Message &
-        (NumberValue | StringValue | BoolValue | BytesValue),
-      typeName
+        (NumberValue | StringValue | BoolValue | BytesValue)
     );
   }
 

--- a/typescript/src/toproto3json.ts
+++ b/typescript/src/toproto3json.ts
@@ -154,6 +154,10 @@ export function toProto3JSON(obj: protobuf.Message): JSONValue {
       typeof value === 'boolean' ||
       value === null
     ) {
+      if (typeof value === 'number' && !Number.isFinite(value)) {
+        result[key] = value.toString();
+        continue;
+      }
       result[key] = value;
       continue;
     }

--- a/typescript/src/toproto3json.ts
+++ b/typescript/src/toproto3json.ts
@@ -60,7 +60,6 @@ export function toProto3JSON(obj: protobuf.Message): JSONValue {
   }
 
   if (typeName === '.google.protobuf.Value') {
-    console.log('--------typename is .google.protobuf.Value');
     return googleProtobufValueToProto3JSON(obj as protobuf.Message & Value);
   }
 

--- a/typescript/src/toproto3json.ts
+++ b/typescript/src/toproto3json.ts
@@ -60,6 +60,7 @@ export function toProto3JSON(obj: protobuf.Message): JSONValue {
   }
 
   if (typeName === '.google.protobuf.Value') {
+    console.log('--------typename is .google.protobuf.Value');
     return googleProtobufValueToProto3JSON(obj as protobuf.Message & Value);
   }
 
@@ -94,7 +95,8 @@ export function toProto3JSON(obj: protobuf.Message): JSONValue {
   if (wrapperTypes.has(typeName)) {
     return wrapperToProto3JSON(
       obj as protobuf.Message &
-        (NumberValue | StringValue | BoolValue | BytesValue)
+        (NumberValue | StringValue | BoolValue | BytesValue),
+      typeName
     );
   }
 

--- a/typescript/src/value.ts
+++ b/typescript/src/value.ts
@@ -70,6 +70,9 @@ export function googleProtobufValueToProto3JSON(
     Object.prototype.hasOwnProperty.call(obj, 'numberValue') &&
     typeof obj.numberValue === 'number'
   ) {
+    if (!Number.isFinite(obj.numberValue)) {
+      return obj.numberValue.toString();
+    }
     return obj.numberValue;
   }
 
@@ -140,6 +143,15 @@ export function googleProtobufValueFromProto3JSON(
   }
 
   if (typeof json === 'string') {
+    if (json === 'NaN') {
+      return {numberValue: NaN};
+    }
+    if (json === 'Infinity') {
+      return {numberValue: Infinity};
+    }
+    if (json === '-Infinity') {
+      return {numberValue: -Infinity};
+    }
     return {stringValue: json};
   }
 

--- a/typescript/src/value.ts
+++ b/typescript/src/value.ts
@@ -143,15 +143,6 @@ export function googleProtobufValueFromProto3JSON(
   }
 
   if (typeof json === 'string') {
-    if (json === 'NaN') {
-      return {numberValue: NaN};
-    }
-    if (json === 'Infinity') {
-      return {numberValue: Infinity};
-    }
-    if (json === '-Infinity') {
-      return {numberValue: -Infinity};
-    }
     return {stringValue: json};
   }
 

--- a/typescript/src/wrappers.ts
+++ b/typescript/src/wrappers.ts
@@ -33,7 +33,8 @@ export interface BytesValue {
 }
 
 export function wrapperToProto3JSON(
-  obj: protobuf.Message & (NumberValue | StringValue | BoolValue | BytesValue)
+  obj: protobuf.Message & (NumberValue | StringValue | BoolValue | BytesValue),
+  typeName?: string
 ) {
   if (!Object.prototype.hasOwnProperty.call(obj, 'value')) {
     return null;
@@ -47,6 +48,14 @@ export function wrapperToProto3JSON(
       `wrapperToProto3JSON: expected to see a number, a string, a boolean, or a Long, but got ${obj.value}`
     );
     return (obj.value as LongStub).toString();
+  }
+  // JSON accept special string values "NaN", "Infinity", and "-Infinity".
+  if (
+    typeName &&
+    typeName === '.google.protobuf.DoubleValue' &&
+    !Number.isFinite(obj.value)
+  ) {
+    return obj.value.toString();
   }
   return obj.value;
 }

--- a/typescript/src/wrappers.ts
+++ b/typescript/src/wrappers.ts
@@ -33,8 +33,7 @@ export interface BytesValue {
 }
 
 export function wrapperToProto3JSON(
-  obj: protobuf.Message & (NumberValue | StringValue | BoolValue | BytesValue),
-  typeName?: string
+  obj: protobuf.Message & (NumberValue | StringValue | BoolValue | BytesValue)
 ) {
   if (!Object.prototype.hasOwnProperty.call(obj, 'value')) {
     return null;
@@ -50,11 +49,7 @@ export function wrapperToProto3JSON(
     return (obj.value as LongStub).toString();
   }
   // JSON accept special string values "NaN", "Infinity", and "-Infinity".
-  if (
-    typeName &&
-    typeName === '.google.protobuf.DoubleValue' &&
-    !Number.isFinite(obj.value)
-  ) {
+  if (typeof obj.value === 'number' && !Number.isFinite(obj.value)) {
     return obj.value.toString();
   }
   return obj.value;

--- a/typescript/test/unit/primitive.ts
+++ b/typescript/test/unit/primitive.ts
@@ -73,4 +73,54 @@ function testLongIntegers(root: protobuf.Root) {
   });
 }
 
-testTwoTypesOfLoad('primitive types', [testPrimitiveTypes, testLongIntegers]);
+function testNotFiniteNumber(root: protobuf.Root) {
+  const PrimitiveTypes = root.lookupType('test.PrimitiveTypes');
+  const messageNaN = PrimitiveTypes.fromObject({
+    doubleField: NaN,
+  });
+  const jsonNaN = {
+    doubleField: 'NaN',
+  };
+  const messageInfinity = PrimitiveTypes.fromObject({
+    doubleField: Infinity,
+  });
+  const jsonInfinity = {
+    doubleField: 'Infinity',
+  };
+  const messageNegInfinity = PrimitiveTypes.fromObject({
+    doubleField: Infinity,
+  });
+  const jsonNegInfinity = {
+    doubleField: 'Infinity',
+  };
+  it('serializes NaN to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageNaN);
+    assert.deepStrictEqual(serialized, jsonNaN);
+  });
+  it('deserializes NaN from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(PrimitiveTypes, jsonNaN);
+    assert.deepStrictEqual(deserialized, messageNaN);
+  });
+  it('serializes Infinity to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageInfinity);
+    assert.deepStrictEqual(serialized, jsonInfinity);
+  });
+  it('deserializes Infinity from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(PrimitiveTypes, jsonInfinity);
+    assert.deepStrictEqual(deserialized, messageInfinity);
+  });
+  it('serializes negative Infinity to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageNegInfinity);
+    assert.deepStrictEqual(serialized, jsonNegInfinity);
+  });
+  it('deserializes negative Infinity from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(PrimitiveTypes, jsonNegInfinity);
+    assert.deepStrictEqual(deserialized, messageNegInfinity);
+  });
+}
+
+testTwoTypesOfLoad('primitive types', [
+  testPrimitiveTypes,
+  testLongIntegers,
+  testNotFiniteNumber,
+]);

--- a/typescript/test/unit/value.ts
+++ b/typescript/test/unit/value.ts
@@ -33,7 +33,25 @@ function testGoogleProtobufValue(root: protobuf.Root) {
       numberValue: 42,
     },
   });
+  const messageNaN = MessageWithValue.fromObject({
+    valueField: {
+      numberValue: NaN,
+    },
+  });
+  const messageInfinity = MessageWithValue.fromObject({
+    valueField: {
+      numberValue: Infinity,
+    },
+  });
+  const messageNegInfinity = MessageWithValue.fromObject({
+    valueField: {
+      numberValue: -Infinity,
+    },
+  });
   const jsonNumber = {valueField: 42};
+  const jsonNaN = {valueField: 'NaN'};
+  const jsonInfinity = {valueField: 'Infinity'};
+  const jsonNegInfinity = {valueField: '-Infinity'};
   const messageString = MessageWithValue.fromObject({
     valueField: {
       stringValue: 'test',
@@ -139,6 +157,36 @@ function testGoogleProtobufValue(root: protobuf.Root) {
   it('deserializes NumberValue from proto3 JSON', () => {
     const deserialized = fromProto3JSON(MessageWithValue, jsonNumber);
     assert.deepStrictEqual(deserialized, messageNumber);
+  });
+
+  it('serializes NaN to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageNaN);
+    assert.deepStrictEqual(serialized, jsonNaN);
+  });
+
+  it('deserializes NaN from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithValue, jsonNaN);
+    assert.deepStrictEqual(deserialized, messageNaN);
+  });
+
+  it('serializes Infinity to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageInfinity);
+    assert.deepStrictEqual(serialized, jsonInfinity);
+  });
+
+  it('deserializes Infinity from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithValue, jsonInfinity);
+    assert.deepStrictEqual(deserialized, messageInfinity);
+  });
+
+  it('serializes negative Infinity to proto3 JSON', () => {
+    const serialized = toProto3JSON(messageNegInfinity);
+    assert.deepStrictEqual(serialized, jsonNegInfinity);
+  });
+
+  it('deserializes Infinity from proto3 JSON', () => {
+    const deserialized = fromProto3JSON(MessageWithValue, jsonNegInfinity);
+    assert.deepStrictEqual(deserialized, messageNegInfinity);
   });
 
   it('serializes StringValue to proto3 JSON', () => {

--- a/typescript/test/unit/value.ts
+++ b/typescript/test/unit/value.ts
@@ -166,7 +166,17 @@ function testGoogleProtobufValue(root: protobuf.Root) {
 
   it('deserializes NaN from proto3 JSON', () => {
     const deserialized = fromProto3JSON(MessageWithValue, jsonNaN);
-    assert.deepStrictEqual(deserialized, messageNaN);
+    // Attempting to serialize NaN or Infinity results in error.
+    // "NaN" would parse as string_value, not number_value.
+    // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Value
+    assert.deepStrictEqual(
+      deserialized,
+      MessageWithValue.fromObject({
+        valueField: {
+          stringValue: 'NaN',
+        },
+      })
+    );
   });
 
   it('serializes Infinity to proto3 JSON', () => {
@@ -176,7 +186,17 @@ function testGoogleProtobufValue(root: protobuf.Root) {
 
   it('deserializes Infinity from proto3 JSON', () => {
     const deserialized = fromProto3JSON(MessageWithValue, jsonInfinity);
-    assert.deepStrictEqual(deserialized, messageInfinity);
+    // Attempting to serialize NaN or Infinity results in error.
+    // "Infinity" would parse as string_value, not number_value.
+    // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Value
+    assert.deepStrictEqual(
+      deserialized,
+      MessageWithValue.fromObject({
+        valueField: {
+          stringValue: 'Infinity',
+        },
+      })
+    );
   });
 
   it('serializes negative Infinity to proto3 JSON', () => {
@@ -186,7 +206,17 @@ function testGoogleProtobufValue(root: protobuf.Root) {
 
   it('deserializes Infinity from proto3 JSON', () => {
     const deserialized = fromProto3JSON(MessageWithValue, jsonNegInfinity);
-    assert.deepStrictEqual(deserialized, messageNegInfinity);
+    // Attempting to serialize NaN, Infinity, negative Infinity results in error.
+    // "-Infinity" would parse as string_value, not number_value.
+    // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Value
+    assert.deepStrictEqual(
+      deserialized,
+      MessageWithValue.fromObject({
+        valueField: {
+          stringValue: '-Infinity',
+        },
+      })
+    );
   });
 
   it('serializes StringValue to proto3 JSON', () => {

--- a/typescript/test/unit/wrappers.ts
+++ b/typescript/test/unit/wrappers.ts
@@ -32,6 +32,9 @@ function testWrapperTypes(root: protobuf.Root) {
     boolValueField: {value: true},
     stringValueField: {value: 'test'},
     bytesValueField: {value: buffer},
+    nanValueField: {value: NaN},
+    infinityValueField: {value: Infinity},
+    negativeInfinityValueField: {value: -Infinity},
   });
   const json = {
     doubleValueField: 3.14,
@@ -43,6 +46,9 @@ function testWrapperTypes(root: protobuf.Root) {
     boolValueField: true,
     stringValueField: 'test',
     bytesValueField: buffer.toString('base64'),
+    nanValueField: 'NaN',
+    infinityValueField: 'Infinity',
+    negativeInfinityValueField: '-Infinity',
   };
 
   const messageWithNulls = MessageWithWrappers.fromObject({


### PR DESCRIPTION
Convert proto3 `DoubleValue` message value `NaN`, `Infinity`, and `-Infinity` as string according to spec:

> JSON value will be a number or one of the special string values "NaN", "Infinity", and "-Infinity". Either numbers or strings are accepted. Exponent notation is also accepted. -0 is considered equivalent to 0.

source: https://developers.google.com/protocol-buffers/docs/proto3

Implement 3 types:
- Primitive Type:
- `google.protobuf.Value`
- `google.protobuf.DoubleValue`




