### PR TITLE
fix: keep nano second precision when maps between JSON and proto3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 15]
+        node: [10, 12, 14, 15, 16]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 15, 16]
+        node: [10, 12, 14, 16]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/typescript/src/timestamp.ts
+++ b/typescript/src/timestamp.ts
@@ -26,19 +26,11 @@ export function googleProtobufTimestampToProto3JSON(
   // seconds is an instance of Long so it won't be undefined
   const durationSeconds = obj.seconds;
   const date = new Date(durationSeconds * 1000).toISOString();
-  let nanos = obj.nanos + '';
-  // Append leading zeros if nano string length is less than 9.
-  while (nanos.length < 9) {
-    nanos = '0' + nanos;
-  }
-  // Trim the unsignificant zeros and keep 0, 3, 6, or 9 decimal digits.
-  while (nanos.length > 3) {
-    const lastThree = nanos.substring(nanos.length - 3);
-    if (~~lastThree === 0) {
-      nanos = nanos.slice(0, -3);
-    } else {
-      break;
-    }
+  // Pad leading zeros if nano string length is less than 9.
+  let nanos = obj.nanos?.toString().padStart(9, '0');
+  // Trim the unsignificant zeros and keep 3, 6, or 9 decimal digits.
+  while (nanos && nanos.length > 3 && nanos.endsWith('000')) {
+    nanos = nanos.slice(0, -3);
   }
   return date.replace(/(?:\.\d{0,9})/, '.' + nanos);
 }
@@ -57,9 +49,7 @@ export function googleProtobufTimestampFromProto3JSON(json: string) {
   // The fractional seconds in the JSON timestamps can go up to 9 digits (i.e. up to 1 nanosecond resolution).
   // However, Javascript Date object represent any date and time to millisecond precision.
   // To keep the precision, we extract the fractional seconds and append 0 until the length is equal to 9.
-  const nanos = parseInt(
-    (json.split('.')[1].slice(0, -1) + '000000000').slice(0, 9)
-  );
+  const nanos = parseInt(json.split('.')[1].slice(0, -1).padEnd(9, '0'));
 
   const result: FromObjectValue = {};
   if (seconds !== 0) {

--- a/typescript/test/unit/timestamp.ts
+++ b/typescript/test/unit/timestamp.ts
@@ -29,6 +29,14 @@ function testTimestamp(root: protobuf.Root) {
     },
     {timestamp: {nanos: 10000000}, value: '1970-01-01T00:00:00.010Z'},
     {timestamp: {seconds: 1484443815}, value: '2017-01-15T01:30:15.000Z'},
+    {
+      timestamp: {seconds: 1642115149, nanos: 91148000},
+      value: '2022-01-13T23:05:49.091148Z',
+    },
+    {
+      timestamp: {seconds: 1642121565, nanos: 10000},
+      value: '2022-01-14T00:52:45.000010Z',
+    },
   ];
 
   for (const mapping of testMapping) {

--- a/typescript/test/unit/timestamp.ts
+++ b/typescript/test/unit/timestamp.ts
@@ -37,6 +37,10 @@ function testTimestamp(root: protobuf.Root) {
       timestamp: {seconds: 1642121565, nanos: 10000},
       value: '2022-01-14T00:52:45.000010Z',
     },
+    {
+      timestamp: {seconds: 1642121565, nanos: 123456789},
+      value: '2022-01-14T00:52:45.123456789Z',
+    },
   ];
 
   for (const mapping of testMapping) {


### PR DESCRIPTION
The fractional seconds in the JSON timestamps can go up to 9 digits (i.e. up to 1 nanosecond resolution). [timestamps.proto](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/timestamp.proto#L115)
However, Javascript Date object represent any date and time to millisecond precision.

To keep the precision, we extract the fractional seconds and append 0 until the length is equal to 9.
