### PR TITLE
fix: timestamp without millisecond

### DIFF
--- a/typescript/src/timestamp.ts
+++ b/typescript/src/timestamp.ts
@@ -25,6 +25,8 @@ export function googleProtobufTimestampToProto3JSON(
 ) {
   // seconds is an instance of Long so it won't be undefined
   const durationSeconds = obj.seconds;
+  console.log('--obj: ', obj);
+  console.log('--duration: ', durationSeconds);
   const date = new Date(durationSeconds * 1000).toISOString();
   // Pad leading zeros if nano string length is less than 9.
   let nanos = obj.nanos?.toString().padStart(9, '0');
@@ -36,21 +38,26 @@ export function googleProtobufTimestampToProto3JSON(
 }
 
 export function googleProtobufTimestampFromProto3JSON(json: string) {
+  console.log('+++++++++++++++++++++++');
   const match = json.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?/);
   if (!match) {
     throw new Error(
       `googleProtobufDurationFromProto3JSON: incorrect value ${json} passed as google.protobuf.Duration`
     );
   }
-
+  console.log('---------jsn: ', json);
   const date = new Date(json);
+  console.log('--date receive: ', date);
   const millisecondsSinceEpoch = date.getTime();
   const seconds = Math.floor(millisecondsSinceEpoch / 1000);
   // The fractional seconds in the JSON timestamps can go up to 9 digits (i.e. up to 1 nanosecond resolution).
   // However, Javascript Date object represent any date and time to millisecond precision.
   // To keep the precision, we extract the fractional seconds and append 0 until the length is equal to 9.
-  const nanos = parseInt(json.split('.')[1].slice(0, -1).padEnd(9, '0'));
-
+  let nanos = 0;
+  const secondsFromDate = json.split('.')[1];
+  if (secondsFromDate) {
+    nanos = parseInt(secondsFromDate.slice(0, -1).padEnd(9, '0'));
+  }
   const result: FromObjectValue = {};
   if (seconds !== 0) {
     result.seconds = seconds;

--- a/typescript/src/timestamp.ts
+++ b/typescript/src/timestamp.ts
@@ -25,8 +25,6 @@ export function googleProtobufTimestampToProto3JSON(
 ) {
   // seconds is an instance of Long so it won't be undefined
   const durationSeconds = obj.seconds;
-  console.log('--obj: ', obj);
-  console.log('--duration: ', durationSeconds);
   const date = new Date(durationSeconds * 1000).toISOString();
   // Pad leading zeros if nano string length is less than 9.
   let nanos = obj.nanos?.toString().padStart(9, '0');
@@ -38,16 +36,13 @@ export function googleProtobufTimestampToProto3JSON(
 }
 
 export function googleProtobufTimestampFromProto3JSON(json: string) {
-  console.log('+++++++++++++++++++++++');
   const match = json.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?/);
   if (!match) {
     throw new Error(
       `googleProtobufDurationFromProto3JSON: incorrect value ${json} passed as google.protobuf.Duration`
     );
   }
-  console.log('---------jsn: ', json);
   const date = new Date(json);
-  console.log('--date receive: ', date);
   const millisecondsSinceEpoch = date.getTime();
   const seconds = Math.floor(millisecondsSinceEpoch / 1000);
   // The fractional seconds in the JSON timestamps can go up to 9 digits (i.e. up to 1 nanosecond resolution).

--- a/typescript/test/unit/timestamp.ts
+++ b/typescript/test/unit/timestamp.ts
@@ -68,13 +68,10 @@ function testTimestamp(root: protobuf.Root) {
 
   describe('Timestamp has no millisecond', () => {
     const message = MessageWithTimestamp.fromObject({
-      timestampField: {timestamp: {second: 1640995200, nanos: 0}},
+      timestampField: {seconds: 1640995200},
     });
-    console.log('--meesgae:: ', message);
-    // eslint-disable-next-line no-restricted-properties
-    it.only('serialized date has no second to proto3 JSON', () => {
+    it('serialized date has no second to proto3 JSON', () => {
       const serialized = toProto3JSON(message);
-      console.log('--serialized: ', serialized);
       assert.deepStrictEqual(serialized, {
         timestampField: '2022-01-01T00:00:00.000Z',
       });

--- a/typescript/test/unit/timestamp.ts
+++ b/typescript/test/unit/timestamp.ts
@@ -41,6 +41,10 @@ function testTimestamp(root: protobuf.Root) {
       timestamp: {seconds: 1642121565, nanos: 123456789},
       value: '2022-01-14T00:52:45.123456789Z',
     },
+    {
+      timestamp: {seconds: 1640995200},
+      value: '2022-01-01T00:00:00.000Z',
+    },
   ];
 
   for (const mapping of testMapping) {
@@ -61,6 +65,28 @@ function testTimestamp(root: protobuf.Root) {
       assert.deepStrictEqual(deserialized, message);
     });
   }
+
+  describe('Timestamp has no millisecond', () => {
+    const message = MessageWithTimestamp.fromObject({
+      timestampField: {timestamp: {second: 1640995200, nanos: 0}},
+    });
+    console.log('--meesgae:: ', message);
+    // eslint-disable-next-line no-restricted-properties
+    it.only('serialized date has no second to proto3 JSON', () => {
+      const serialized = toProto3JSON(message);
+      console.log('--serialized: ', serialized);
+      assert.deepStrictEqual(serialized, {
+        timestampField: '2022-01-01T00:00:00.000Z',
+      });
+    });
+
+    it('deserializes timestamp has no second from proto3 JSON', () => {
+      const deserialized = fromProto3JSON(MessageWithTimestamp, {
+        timestampField: '2022-01-01T00:00:00Z',
+      });
+      assert.deepStrictEqual(deserialized, message);
+    });
+  });
 }
 
 testTwoTypesOfLoad('google.protobuf.Timestamp', testTimestamp);


### PR DESCRIPTION
A timestamp might have no millisecond, form like `2022-01-01T00:00:00Z` vs `2022-01-01T00:00:00.000Z`.


