### PR TITLE
feat: option to serialize enum values as numbers

### DIFF
--- a/typescript/src/any.ts
+++ b/typescript/src/any.ts
@@ -17,7 +17,7 @@
 
 import * as protobuf from 'protobufjs';
 import {fromProto3JSON} from './fromproto3json';
-import {toProto3JSON} from './toproto3json';
+import {toProto3JSON, ToProto3JSONOptions} from './toproto3json';
 import {JSONObject, JSONValue} from './types';
 
 // https://github.com/protocolbuffers/protobuf/blob/ba3836703b4a9e98e474aea2bac8c5b49b6d3b5c/python/google/protobuf/json_format.py#L850
@@ -37,7 +37,8 @@ export interface Any {
 }
 
 export function googleProtobufAnyToProto3JSON(
-  obj: protobuf.Message & Any
+  obj: protobuf.Message & Any,
+  options?: ToProto3JSONOptions
 ): JSONObject {
   // https://developers.google.com/protocol-buffers/docs/proto3#json
   // If the Any contains a value that has a special JSON mapping, it will be converted as follows:
@@ -55,7 +56,7 @@ export function googleProtobufAnyToProto3JSON(
     );
   }
   const valueMessage = type.decode(obj.value);
-  const valueProto3JSON = toProto3JSON(valueMessage);
+  const valueProto3JSON = toProto3JSON(valueMessage, options);
   if (specialJSON.has(typeName)) {
     return {
       '@type': obj.type_url,

--- a/typescript/src/enum.ts
+++ b/typescript/src/enum.ts
@@ -38,3 +38,24 @@ export function resolveEnumValueToString(
     'resolveEnumValueToString: enum value must be a string or a number'
   );
 }
+
+export function resolveEnumValueToNumber(
+  enumType: protobuf.Enum,
+  enumValue: JSONValue
+) {
+  if (typeof enumValue === 'number') {
+    // return as is
+    return enumValue;
+  }
+  if (typeof enumValue === 'string') {
+    const num = enumType.values[enumValue];
+    if (typeof num === 'undefined') {
+      // unknown value, cannot convert to number, returning string as is
+      return enumValue;
+    }
+    return num;
+  }
+  throw new Error(
+    'resolveEnumValueToNumber: enum value must be a string or a number'
+  );
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -13,5 +13,5 @@
 // limitations under the License.
 
 export {JSONObject, JSONValue} from './types';
-export {toProto3JSON} from './toproto3json';
+export {toProto3JSON, ToProto3JSONOptions} from './toproto3json';
 export {fromProto3JSON} from './fromproto3json';

--- a/typescript/test/unit/enum.ts
+++ b/typescript/test/unit/enum.ts
@@ -27,10 +27,19 @@ function testEnum(root: protobuf.Root) {
   const json = {
     enumField: 'KNOWN',
   };
+  const jsonWithNumber = {
+    enumField: 1,
+  };
 
   it('serializes to proto3 JSON', () => {
     const serialized = toProto3JSON(message);
     assert.deepStrictEqual(serialized, json);
+  });
+
+  it('serializes to proto3 JSON with numeric enum values', () => {
+    const serialized = toProto3JSON(message, {numericEnums: true});
+    assert.deepStrictEqual(serialized, jsonWithNumber);
+    console.log(serialized);
   });
 
   it('deserializes from proto3 JSON', () => {


### PR DESCRIPTION
Add an optional parameter to `toProto3JSON` to allow serializing enums as numbers:

```ts
const json = toProto3JSON(obj, {numericEnums: true});
```
