### PR TITLE
fix: repeated field can be null in JSON

### DIFF
--- a/test-fixtures/proto/test.proto
+++ b/test-fixtures/proto/test.proto
@@ -63,6 +63,7 @@ message MapValue {
 message MessageWithRepeated {
     repeated string repeated_string = 3;
     repeated RepeatedValue repeated_message = 4;
+    repeated string one_more_repeated_string = 5;
 }
 
 message RepeatedValue {

--- a/typescript/src/fromproto3json.ts
+++ b/typescript/src/fromproto3json.ts
@@ -139,17 +139,21 @@ export function fromProto3JSONToInternalRepresentation(
     const fieldType = field.type;
 
     if (field.repeated) {
-      if (!Array.isArray(value)) {
-        throw new Error(
-          `fromProto3JSONToInternalRepresentation: expected an array for field ${key}`
+      if (value === null) {
+        result[key] = [];
+      } else {
+        if (!Array.isArray(value)) {
+          throw new Error(
+            `fromProto3JSONToInternalRepresentation: expected an array for field ${key}`
+          );
+        }
+        result[key] = value.map(element =>
+          fromProto3JSONToInternalRepresentation(
+            resolvedType || fieldType,
+            element
+          )
         );
       }
-      result[key] = value.map(element =>
-        fromProto3JSONToInternalRepresentation(
-          resolvedType || fieldType,
-          element
-        )
-      );
     } else if (field.map) {
       const map: FromObjectValue = {};
       for (const [mapKey, mapValue] of Object.entries(value)) {

--- a/typescript/test/unit/repeated.ts
+++ b/typescript/test/unit/repeated.ts
@@ -31,8 +31,33 @@ function testRepeated(root: protobuf.Root) {
         stringField: 'value2',
       },
     ],
+    oneMoreRepeatedString: [],
   });
-  const json = {
+  const jsonWithNull = {
+    repeatedString: ['value1', 'value2', 'value3'],
+    repeatedMessage: [
+      {
+        stringField: 'value1',
+      },
+      {
+        stringField: 'value2',
+      },
+    ],
+    oneMoreRepeatedString: null,
+  };
+  const jsonWithEmptyArray = {
+    repeatedString: ['value1', 'value2', 'value3'],
+    repeatedMessage: [
+      {
+        stringField: 'value1',
+      },
+      {
+        stringField: 'value2',
+      },
+    ],
+    oneMoreRepeatedString: null,
+  };
+  const jsonWithoutEmptyArrays = {
     repeatedString: ['value1', 'value2', 'value3'],
     repeatedMessage: [
       {
@@ -46,11 +71,27 @@ function testRepeated(root: protobuf.Root) {
 
   it('serializes to proto3 JSON', () => {
     const serialized = toProto3JSON(message);
-    assert.deepStrictEqual(serialized, json);
+    assert.deepStrictEqual(serialized, jsonWithoutEmptyArrays);
   });
 
-  it('deserializes from proto3 JSON', () => {
-    const deserialized = fromProto3JSON(MessageWithRepeated, json);
+  it('deserializes from proto3 JSON with null', () => {
+    const deserialized = fromProto3JSON(MessageWithRepeated, jsonWithNull);
+    assert.deepStrictEqual(deserialized, message);
+  });
+
+  it('deserializes from proto3 JSON with an empty array', () => {
+    const deserialized = fromProto3JSON(
+      MessageWithRepeated,
+      jsonWithEmptyArray
+    );
+    assert.deepStrictEqual(deserialized, message);
+  });
+
+  it('deserializes from proto3 JSON with an omitted array field', () => {
+    const deserialized = fromProto3JSON(
+      MessageWithRepeated,
+      jsonWithoutEmptyArrays
+    );
     assert.deepStrictEqual(deserialized, message);
   });
 }
@@ -60,6 +101,7 @@ function testEmptyRepeated(root: protobuf.Root) {
   const message = MessageWithRepeated.fromObject({
     repeatedString: [],
     repeatedMessage: [],
+    oneMoreRepeatedString: [],
   });
   const json = {};
 


### PR DESCRIPTION
According to the [spec](https://protobuf.dev/programming-guides/proto3/#json), an empty`repeated` field can be represented as `null`:

<img width="949" alt="image" src="https://user-images.githubusercontent.com/4015807/234379939-5dedc53d-828b-4df6-9c77-f895df263d13.png">
