### PR TITLE
fix: properly convert repeated int64 and maps of int64

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "linkinator": "^5.0.0",
     "mocha": "^9.2.2",
     "pack-n-play": "^2.0.0",
+    "protobufjs-cli": "^1.1.2",
     "typescript": "^4.6.4"
   },
   "engines": {

--- a/test-fixtures/proto/test.json
+++ b/test-fixtures/proto/test.json
@@ -81,6 +81,11 @@
               "keyType": "string",
               "type": "string",
               "id": 4
+            },
+            "longMapField": {
+              "keyType": "string",
+              "type": "int64",
+              "id": 5
             }
           }
         },
@@ -103,6 +108,16 @@
               "rule": "repeated",
               "type": "RepeatedValue",
               "id": 4
+            },
+            "oneMoreRepeatedString": {
+              "rule": "repeated",
+              "type": "string",
+              "id": 5
+            },
+            "repeatedLong": {
+              "rule": "repeated",
+              "type": "int64",
+              "id": 6
             }
           }
         },

--- a/test-fixtures/proto/test.proto
+++ b/test-fixtures/proto/test.proto
@@ -54,6 +54,7 @@ message MessageWithBytesField {
 message MessageWithMap {
     map<string, MapValue> map_field = 3;
     map<string, string> string_map_field = 4;
+    map<string, int64> long_map_field = 5;
 }
 
 message MapValue {
@@ -64,6 +65,7 @@ message MessageWithRepeated {
     repeated string repeated_string = 3;
     repeated RepeatedValue repeated_message = 4;
     repeated string one_more_repeated_string = 5;
+    repeated int64 repeated_long = 6;
 }
 
 message RepeatedValue {

--- a/typescript/test/unit/map.ts
+++ b/typescript/test/unit/map.ts
@@ -34,6 +34,12 @@ function testMap(root: protobuf.Root) {
       key1: 'string value 1',
       key2: 'string value 2',
     },
+    longMapField: {
+      '2^63-1': '9223372036854775807',
+      one: '1',
+      'minus one': '-1',
+      zero: '0',
+    },
   });
   const json = {
     mapField: {
@@ -47,6 +53,12 @@ function testMap(root: protobuf.Root) {
     stringMapField: {
       key1: 'string value 1',
       key2: 'string value 2',
+    },
+    longMapField: {
+      '2^63-1': '9223372036854775807',
+      one: '1',
+      'minus one': '-1',
+      zero: '0',
     },
   };
 

--- a/typescript/test/unit/repeated.ts
+++ b/typescript/test/unit/repeated.ts
@@ -32,6 +32,7 @@ function testRepeated(root: protobuf.Root) {
       },
     ],
     oneMoreRepeatedString: [],
+    repeatedLong: ['9223372036854775807', '1', '-1', '0'],
   });
   const jsonWithNull = {
     repeatedString: ['value1', 'value2', 'value3'],
@@ -44,6 +45,7 @@ function testRepeated(root: protobuf.Root) {
       },
     ],
     oneMoreRepeatedString: null,
+    repeatedLong: ['9223372036854775807', '1', '-1', '0'],
   };
   const jsonWithEmptyArray = {
     repeatedString: ['value1', 'value2', 'value3'],
@@ -56,6 +58,7 @@ function testRepeated(root: protobuf.Root) {
       },
     ],
     oneMoreRepeatedString: null,
+    repeatedLong: ['9223372036854775807', '1', '-1', '0'],
   };
   const jsonWithoutEmptyArrays = {
     repeatedString: ['value1', 'value2', 'value3'],
@@ -67,6 +70,7 @@ function testRepeated(root: protobuf.Root) {
         stringField: 'value2',
       },
     ],
+    repeatedLong: ['9223372036854775807', '1', '-1', '0'],
   };
 
   it('serializes to proto3 JSON', () => {


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-node/issues/4743.

We support `Long` type (which is the `protobufjs` representation of `int64` and `uint64`), but one very special case, where the proto contains either `repeated int64` or `map<..., int64>`, does not work properly. Fixing that.

An unrelated change is to add `protobufjs-cli` to `devDependencies`; it's now needed for running `npm run compile-test-protos` to regenerate the fixtures. It was not needed before since `pbjs` was originally a part of `protobufjs`, but now it lives in a separate package.

_On a personal note, I'm quite happy that my last code change while working for Google is for this library, which I created and published about [3 years ago](https://github.com/googleapis/proto3-json-serializer-nodejs/pull/2), and enjoyed working on :)_