### PR TITLE
fix: Fix enum serialization in maps and repeated fields

### DIFF
--- a/test-fixtures/proto/test.json
+++ b/test-fixtures/proto/test.json
@@ -86,6 +86,11 @@
               "keyType": "string",
               "type": "int64",
               "id": 5
+            },
+            "enumMapField": {
+              "keyType": "string",
+              "type": "Enum",
+              "id": 6
             }
           }
         },

--- a/test-fixtures/proto/test.json
+++ b/test-fixtures/proto/test.json
@@ -118,6 +118,11 @@
               "rule": "repeated",
               "type": "int64",
               "id": 6
+            },
+            "repeatedEnum": {
+              "rule": "repeated",
+              "type": "Enum",
+              "id": 7
             }
           }
         },

--- a/test-fixtures/proto/test.proto
+++ b/test-fixtures/proto/test.proto
@@ -55,6 +55,7 @@ message MessageWithMap {
     map<string, MapValue> map_field = 3;
     map<string, string> string_map_field = 4;
     map<string, int64> long_map_field = 5;
+    map<string, Enum> enum_map_field = 6;
 }
 
 message MapValue {

--- a/test-fixtures/proto/test.proto
+++ b/test-fixtures/proto/test.proto
@@ -66,6 +66,7 @@ message MessageWithRepeated {
     repeated RepeatedValue repeated_message = 4;
     repeated string one_more_repeated_string = 5;
     repeated int64 repeated_long = 6;
+    repeated Enum repeated_enum = 7;
 }
 
 message RepeatedValue {

--- a/typescript/src/toproto3json.ts
+++ b/typescript/src/toproto3json.ts
@@ -141,11 +141,11 @@ export function toProto3JSON(
               return resolveEnumValueToString(fieldResolvedType, element);
             }
           }
-          // if the repeated value has a complex type, convert if to proto3 JSON
+          // if the repeated value has a complex type, convert it to proto3 JSON
           : element => {
               return toProto3JSON(element, options);
             }
-          // otherwise, use as is
+          // otherwise, use the value as-is
           : convertSingleValue,
       );
       continue;
@@ -153,9 +153,15 @@ export function toProto3JSON(
     if (field.map) {
       const map: JSONObject = {};
       for (const [mapKey, mapValue] of Object.entries(value)) {
-        // if the map value has a complex type, convert it to proto3 JSON, otherwise use as is
         map[mapKey] = fieldResolvedType
-          ? toProto3JSON(mapValue as protobuf.Message, options)
+          // if the map value is an enum, resolve the values
+          ? 'values' in fieldResolvedType
+          ? options?.numericEnums
+          ? resolveEnumValueToNumber(fieldResolvedType, mapValue as JSONValue)
+          : resolveEnumValueToString(fieldResolvedType, mapValue as JSONValue)
+          //  if the value is a complex type, convert it to proto3 JSON
+          : toProto3JSON(mapValue as protobuf.Message, options)
+          // otherwise use the value as-is 
           : convertSingleValue(mapValue as JSONValue);
       }
       result[key] = map;

--- a/typescript/src/toproto3json.ts
+++ b/typescript/src/toproto3json.ts
@@ -132,21 +132,21 @@ export function toProto3JSON(
       }
       result[key] = value.map(
         fieldResolvedType
-          // if the repeated value is an enum, resolve the values
-          ? 'values' in fieldResolvedType
-          ? element => {
-            if (options?.numericEnums) {
-              return resolveEnumValueToNumber(fieldResolvedType, element);
-            } else {
-              return resolveEnumValueToString(fieldResolvedType, element);
-            }
-          }
-          // if the repeated value has a complex type, convert it to proto3 JSON
-          : element => {
-              return toProto3JSON(element, options);
-            }
-          // otherwise, use the value as-is
-          : convertSingleValue,
+          ? // if the repeated value is an enum, resolve the values
+            'values' in fieldResolvedType
+            ? element => {
+                if (options?.numericEnums) {
+                  return resolveEnumValueToNumber(fieldResolvedType, element);
+                } else {
+                  return resolveEnumValueToString(fieldResolvedType, element);
+                }
+              }
+            : // if the repeated value has a complex type, convert it to proto3 JSON
+              element => {
+                return toProto3JSON(element, options);
+              }
+          : // otherwise, use the value as-is
+            convertSingleValue,
       );
       continue;
     }
@@ -154,15 +154,21 @@ export function toProto3JSON(
       const map: JSONObject = {};
       for (const [mapKey, mapValue] of Object.entries(value)) {
         map[mapKey] = fieldResolvedType
-          // if the map value is an enum, resolve the values
-          ? 'values' in fieldResolvedType
-          ? options?.numericEnums
-          ? resolveEnumValueToNumber(fieldResolvedType, mapValue as JSONValue)
-          : resolveEnumValueToString(fieldResolvedType, mapValue as JSONValue)
-          //  if the value is a complex type, convert it to proto3 JSON
-          : toProto3JSON(mapValue as protobuf.Message, options)
-          // otherwise use the value as-is 
-          : convertSingleValue(mapValue as JSONValue);
+          ? // if the map value is an enum, resolve the values
+            'values' in fieldResolvedType
+            ? options?.numericEnums
+              ? resolveEnumValueToNumber(
+                  fieldResolvedType,
+                  mapValue as JSONValue,
+                )
+              : resolveEnumValueToString(
+                  fieldResolvedType,
+                  mapValue as JSONValue,
+                )
+            : //  if the value is a complex type, convert it to proto3 JSON
+              toProto3JSON(mapValue as protobuf.Message, options)
+          : // otherwise use the value as-is
+            convertSingleValue(mapValue as JSONValue);
       }
       result[key] = map;
       continue;

--- a/typescript/src/toproto3json.ts
+++ b/typescript/src/toproto3json.ts
@@ -130,12 +130,22 @@ export function toProto3JSON(
         // ignore repeated fields with no values
         continue;
       }
-      // if the repeated value has a complex type, convert it to proto3 JSON, otherwise use as is
       result[key] = value.map(
         fieldResolvedType
+          // if the repeated value is an enum, resolve the values
+          ? 'values' in fieldResolvedType
           ? element => {
+            if (options?.numericEnums) {
+              return resolveEnumValueToNumber(fieldResolvedType, element);
+            } else {
+              return resolveEnumValueToString(fieldResolvedType, element);
+            }
+          }
+          // if the repeated value has a complex type, convert if to proto3 JSON
+          : element => {
               return toProto3JSON(element, options);
             }
+          // otherwise, use as is
           : convertSingleValue,
       );
       continue;

--- a/typescript/test/unit/map.ts
+++ b/typescript/test/unit/map.ts
@@ -122,53 +122,5 @@ function testEnumMap(root: protobuf.Root) {
   });
 }
 
-function testEnumMap(root: protobuf.Root) {
-  const MessageWithMap = root.lookupType('test.MessageWithMap');
-  const message = MessageWithMap.fromObject({
-    enumMapField: {
-      key1: 'UNKNOWN',
-      key2: 'KNOWN',
-    },
-  });
-  const jsonWithStringEnums = {
-    mapField: {},
-    stringMapField: {},
-    longMapField: {},
-    enumMapField: {
-      key1: 'UNKNOWN',
-      key2: 'KNOWN',
-    },
-  };
-  const jsonWithNumericEnums = {
-    mapField: {},
-    stringMapField: {},
-    longMapField: {},
-    enumMapField: {
-      key1: 0,
-      key2: 1,
-    },
-  };
-
-  it('serializes to proto3 JSON with string enums', () => {
-    const serialized = toProto3JSON(message, {numericEnums: false});
-    assert.deepStrictEqual(serialized, jsonWithStringEnums);
-  });
-
-  it('serializes to proto3 JSON with numeric enums', () => {
-    const serialized = toProto3JSON(message, {numericEnums: true});
-    assert.deepStrictEqual(serialized, jsonWithNumericEnums);
-  });
-
-  it('deserializes from proto3 JSON with string enums', () => {
-    const deserialized = fromProto3JSON(MessageWithMap, jsonWithStringEnums);
-    assert.deepStrictEqual(deserialized, message);
-  });
-
-  it('deserializes from proto3 JSON with numeric enums', () => {
-    const deserialized = fromProto3JSON(MessageWithMap, jsonWithNumericEnums);
-    assert.deepStrictEqual(deserialized, message);
-  });
-}
-
 testTwoTypesOfLoad('map fields', testMap);
 testTwoTypesOfLoad('enum map fields', testEnumMap);

--- a/typescript/test/unit/map.ts
+++ b/typescript/test/unit/map.ts
@@ -18,7 +18,6 @@ import {it} from 'mocha';
 import {fromProto3JSON} from '../../src/fromproto3json';
 import {toProto3JSON} from '../../src/toproto3json';
 import {testTwoTypesOfLoad} from './common';
-import { json } from 'stream/consumers';
 
 function testMap(root: protobuf.Root) {
   const MessageWithMap = root.lookupType('test.MessageWithMap');
@@ -80,8 +79,8 @@ function testEnumMap(root: protobuf.Root) {
   const message = MessageWithMap.fromObject({
     enumMapField: {
       key1: 'UNKNOWN',
-      key2: 'KNOWN'
-    }
+      key2: 'KNOWN',
+    },
   });
   const jsonWithStringEnums = {
     mapField: {},
@@ -89,8 +88,8 @@ function testEnumMap(root: protobuf.Root) {
     longMapField: {},
     enumMapField: {
       key1: 'UNKNOWN',
-      key2: 'KNOWN'
-    }
+      key2: 'KNOWN',
+    },
   };
   const jsonWithNumericEnums = {
     mapField: {},
@@ -98,17 +97,17 @@ function testEnumMap(root: protobuf.Root) {
     longMapField: {},
     enumMapField: {
       key1: 0,
-      key2: 1
-    }
+      key2: 1,
+    },
   };
 
   it('serializes to proto3 JSON with string enums', () => {
-    const serialized = toProto3JSON(message, { numericEnums: false });
+    const serialized = toProto3JSON(message, {numericEnums: false});
     assert.deepStrictEqual(serialized, jsonWithStringEnums);
   });
 
   it('serializes to proto3 JSON with numeric enums', () => {
-    const serialized = toProto3JSON(message, { numericEnums: true });
+    const serialized = toProto3JSON(message, {numericEnums: true});
     assert.deepStrictEqual(serialized, jsonWithNumericEnums);
   });
 
@@ -123,5 +122,53 @@ function testEnumMap(root: protobuf.Root) {
   });
 }
 
-//testTwoTypesOfLoad('map fields', testMap);
+function testEnumMap(root: protobuf.Root) {
+  const MessageWithMap = root.lookupType('test.MessageWithMap');
+  const message = MessageWithMap.fromObject({
+    enumMapField: {
+      key1: 'UNKNOWN',
+      key2: 'KNOWN',
+    },
+  });
+  const jsonWithStringEnums = {
+    mapField: {},
+    stringMapField: {},
+    longMapField: {},
+    enumMapField: {
+      key1: 'UNKNOWN',
+      key2: 'KNOWN',
+    },
+  };
+  const jsonWithNumericEnums = {
+    mapField: {},
+    stringMapField: {},
+    longMapField: {},
+    enumMapField: {
+      key1: 0,
+      key2: 1,
+    },
+  };
+
+  it('serializes to proto3 JSON with string enums', () => {
+    const serialized = toProto3JSON(message, {numericEnums: false});
+    assert.deepStrictEqual(serialized, jsonWithStringEnums);
+  });
+
+  it('serializes to proto3 JSON with numeric enums', () => {
+    const serialized = toProto3JSON(message, {numericEnums: true});
+    assert.deepStrictEqual(serialized, jsonWithNumericEnums);
+  });
+
+  it('deserializes from proto3 JSON with string enums', () => {
+    const deserialized = fromProto3JSON(MessageWithMap, jsonWithStringEnums);
+    assert.deepStrictEqual(deserialized, message);
+  });
+
+  it('deserializes from proto3 JSON with numeric enums', () => {
+    const deserialized = fromProto3JSON(MessageWithMap, jsonWithNumericEnums);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
+testTwoTypesOfLoad('map fields', testMap);
 testTwoTypesOfLoad('enum map fields', testEnumMap);

--- a/typescript/test/unit/map.ts
+++ b/typescript/test/unit/map.ts
@@ -18,6 +18,7 @@ import {it} from 'mocha';
 import {fromProto3JSON} from '../../src/fromproto3json';
 import {toProto3JSON} from '../../src/toproto3json';
 import {testTwoTypesOfLoad} from './common';
+import { json } from 'stream/consumers';
 
 function testMap(root: protobuf.Root) {
   const MessageWithMap = root.lookupType('test.MessageWithMap');
@@ -60,6 +61,7 @@ function testMap(root: protobuf.Root) {
       'minus one': '-1',
       zero: '0',
     },
+    enumMapField: {},
   };
 
   it('serializes to proto3 JSON', () => {
@@ -73,4 +75,53 @@ function testMap(root: protobuf.Root) {
   });
 }
 
-testTwoTypesOfLoad('map fields', testMap);
+function testEnumMap(root: protobuf.Root) {
+  const MessageWithMap = root.lookupType('test.MessageWithMap');
+  const message = MessageWithMap.fromObject({
+    enumMapField: {
+      key1: 'UNKNOWN',
+      key2: 'KNOWN'
+    }
+  });
+  const jsonWithStringEnums = {
+    mapField: {},
+    stringMapField: {},
+    longMapField: {},
+    enumMapField: {
+      key1: 'UNKNOWN',
+      key2: 'KNOWN'
+    }
+  };
+  const jsonWithNumericEnums = {
+    mapField: {},
+    stringMapField: {},
+    longMapField: {},
+    enumMapField: {
+      key1: 0,
+      key2: 1
+    }
+  };
+
+  it('serializes to proto3 JSON with string enums', () => {
+    const serialized = toProto3JSON(message, { numericEnums: false });
+    assert.deepStrictEqual(serialized, jsonWithStringEnums);
+  });
+
+  it('serializes to proto3 JSON with numeric enums', () => {
+    const serialized = toProto3JSON(message, { numericEnums: true });
+    assert.deepStrictEqual(serialized, jsonWithNumericEnums);
+  });
+
+  it('deserializes from proto3 JSON with string enums', () => {
+    const deserialized = fromProto3JSON(MessageWithMap, jsonWithStringEnums);
+    assert.deepStrictEqual(deserialized, message);
+  });
+
+  it('deserializes from proto3 JSON with numeric enums', () => {
+    const deserialized = fromProto3JSON(MessageWithMap, jsonWithNumericEnums);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
+//testTwoTypesOfLoad('map fields', testMap);
+testTwoTypesOfLoad('enum map fields', testEnumMap);

--- a/typescript/test/unit/repeated.ts
+++ b/typescript/test/unit/repeated.ts
@@ -33,6 +33,7 @@ function testRepeated(root: protobuf.Root) {
     ],
     oneMoreRepeatedString: [],
     repeatedLong: ['9223372036854775807', '1', '-1', '0'],
+    repeatedEnum: ['UNKNOWN', 'KNOWN']
   });
   const jsonWithNull = {
     repeatedString: ['value1', 'value2', 'value3'],
@@ -46,6 +47,7 @@ function testRepeated(root: protobuf.Root) {
     ],
     oneMoreRepeatedString: null,
     repeatedLong: ['9223372036854775807', '1', '-1', '0'],
+    repeatedEnum: ['UNKNOWN','KNOWN'],
   };
   const jsonWithEmptyArray = {
     repeatedString: ['value1', 'value2', 'value3'],
@@ -59,6 +61,7 @@ function testRepeated(root: protobuf.Root) {
     ],
     oneMoreRepeatedString: null,
     repeatedLong: ['9223372036854775807', '1', '-1', '0'],
+    repeatedEnum: ['UNKNOWN','KNOWN'],
   };
   const jsonWithoutEmptyArrays = {
     repeatedString: ['value1', 'value2', 'value3'],
@@ -71,10 +74,16 @@ function testRepeated(root: protobuf.Root) {
       },
     ],
     repeatedLong: ['9223372036854775807', '1', '-1', '0'],
+    repeatedEnum: ['UNKNOWN','KNOWN'],
   };
 
-  it('serializes to proto3 JSON', () => {
-    const serialized = toProto3JSON(message);
+  it.skip('serializes to proto3 JSON with string enums', () => {
+    const serialized = toProto3JSON(message, { numericEnums: false});
+    assert.deepStrictEqual(serialized, jsonWithoutEmptyArrays);
+  });
+
+  it.skip('serializes to proto3 JSON with numeric enums', () => {
+    const serialized = toProto3JSON(message, { numericEnums: true });
     assert.deepStrictEqual(serialized, jsonWithoutEmptyArrays);
   });
 

--- a/typescript/test/unit/repeated.ts
+++ b/typescript/test/unit/repeated.ts
@@ -57,7 +57,7 @@ function testRepeated(root: protobuf.Root) {
         stringField: 'value2',
       },
     ],
-    oneMoreRepeatedString: null, 
+    oneMoreRepeatedString: null,
     repeatedLong: ['9223372036854775807', '1', '-1', '0'],
   };
   const jsonWithoutEmptyArrays = {
@@ -74,7 +74,7 @@ function testRepeated(root: protobuf.Root) {
   };
 
   it('serializes to proto3 JSON', () => {
-    const serialized = toProto3JSON(message, { numericEnums: true });
+    const serialized = toProto3JSON(message, {numericEnums: true});
     assert.deepStrictEqual(serialized, jsonWithoutEmptyArrays);
   });
 
@@ -127,29 +127,35 @@ function testRepeatedEnum(root: protobuf.Root) {
     repeatedEnum: ['UNKNOWN', 'KNOWN'],
   });
   const jsonWithNumericEnums = {
-    repeatedEnum: [0, 1]
-  }
+    repeatedEnum: [0, 1],
+  };
   const jsonWithStringEnums = {
-    repeatedEnum: ['UNKNOWN', 'KNOWN']
-  }
+    repeatedEnum: ['UNKNOWN', 'KNOWN'],
+  };
 
   it('serializes to proto3 JSON with numeric enums', () => {
-    const serialized = toProto3JSON(message, { numericEnums: true });
+    const serialized = toProto3JSON(message, {numericEnums: true});
     assert.deepStrictEqual(serialized, jsonWithNumericEnums);
   });
 
   it('serializes to proto3 JSON with string enums', () => {
-    const serialized = toProto3JSON(message, { numericEnums: false });
+    const serialized = toProto3JSON(message, {numericEnums: false});
     assert.deepStrictEqual(serialized, jsonWithStringEnums);
   });
 
   it('deserializes from proto3 JSON with numeric enums', () => {
-    const deserialized = fromProto3JSON(MessageWithRepeated, jsonWithNumericEnums);
+    const deserialized = fromProto3JSON(
+      MessageWithRepeated,
+      jsonWithNumericEnums,
+    );
     assert.deepStrictEqual(deserialized, message);
   });
 
   it('deserializes from proto3 JSON with string enums', () => {
-    const deserialized = fromProto3JSON(MessageWithRepeated, jsonWithStringEnums);
+    const deserialized = fromProto3JSON(
+      MessageWithRepeated,
+      jsonWithStringEnums,
+    );
     assert.deepStrictEqual(deserialized, message);
   });
 }

--- a/typescript/test/unit/repeated.ts
+++ b/typescript/test/unit/repeated.ts
@@ -74,7 +74,7 @@ function testRepeated(root: protobuf.Root) {
   };
 
   it('serializes to proto3 JSON', () => {
-    const serialized = toProto3JSON(message, {numericEnums: true});
+    const serialized = toProto3JSON(message);
     assert.deepStrictEqual(serialized, jsonWithoutEmptyArrays);
   });
 

--- a/typescript/test/unit/repeated.ts
+++ b/typescript/test/unit/repeated.ts
@@ -33,7 +33,6 @@ function testRepeated(root: protobuf.Root) {
     ],
     oneMoreRepeatedString: [],
     repeatedLong: ['9223372036854775807', '1', '-1', '0'],
-    repeatedEnum: ['UNKNOWN', 'KNOWN']
   });
   const jsonWithNull = {
     repeatedString: ['value1', 'value2', 'value3'],
@@ -47,7 +46,6 @@ function testRepeated(root: protobuf.Root) {
     ],
     oneMoreRepeatedString: null,
     repeatedLong: ['9223372036854775807', '1', '-1', '0'],
-    repeatedEnum: ['UNKNOWN','KNOWN'],
   };
   const jsonWithEmptyArray = {
     repeatedString: ['value1', 'value2', 'value3'],
@@ -59,9 +57,8 @@ function testRepeated(root: protobuf.Root) {
         stringField: 'value2',
       },
     ],
-    oneMoreRepeatedString: null,
+    oneMoreRepeatedString: null, 
     repeatedLong: ['9223372036854775807', '1', '-1', '0'],
-    repeatedEnum: ['UNKNOWN','KNOWN'],
   };
   const jsonWithoutEmptyArrays = {
     repeatedString: ['value1', 'value2', 'value3'],
@@ -74,15 +71,9 @@ function testRepeated(root: protobuf.Root) {
       },
     ],
     repeatedLong: ['9223372036854775807', '1', '-1', '0'],
-    repeatedEnum: ['UNKNOWN','KNOWN'],
   };
 
-  it.skip('serializes to proto3 JSON with string enums', () => {
-    const serialized = toProto3JSON(message, { numericEnums: false});
-    assert.deepStrictEqual(serialized, jsonWithoutEmptyArrays);
-  });
-
-  it.skip('serializes to proto3 JSON with numeric enums', () => {
+  it('serializes to proto3 JSON', () => {
     const serialized = toProto3JSON(message, { numericEnums: true });
     assert.deepStrictEqual(serialized, jsonWithoutEmptyArrays);
   });
@@ -115,6 +106,7 @@ function testEmptyRepeated(root: protobuf.Root) {
     repeatedString: [],
     repeatedMessage: [],
     oneMoreRepeatedString: [],
+    repeatedEnum: [],
   });
   const json = {};
 
@@ -129,5 +121,39 @@ function testEmptyRepeated(root: protobuf.Root) {
   });
 }
 
+function testRepeatedEnum(root: protobuf.Root) {
+  const MessageWithRepeated = root.lookupType('test.MessageWithRepeated');
+  const message = MessageWithRepeated.fromObject({
+    repeatedEnum: ['UNKNOWN', 'KNOWN'],
+  });
+  const jsonWithNumericEnums = {
+    repeatedEnum: [0, 1]
+  }
+  const jsonWithStringEnums = {
+    repeatedEnum: ['UNKNOWN', 'KNOWN']
+  }
+
+  it('serializes to proto3 JSON with numeric enums', () => {
+    const serialized = toProto3JSON(message, { numericEnums: true });
+    assert.deepStrictEqual(serialized, jsonWithNumericEnums);
+  });
+
+  it('serializes to proto3 JSON with string enums', () => {
+    const serialized = toProto3JSON(message, { numericEnums: false });
+    assert.deepStrictEqual(serialized, jsonWithStringEnums);
+  });
+
+  it('deserializes from proto3 JSON with numeric enums', () => {
+    const deserialized = fromProto3JSON(MessageWithRepeated, jsonWithNumericEnums);
+    assert.deepStrictEqual(deserialized, message);
+  });
+
+  it('deserializes from proto3 JSON with string enums', () => {
+    const deserialized = fromProto3JSON(MessageWithRepeated, jsonWithStringEnums);
+    assert.deepStrictEqual(deserialized, message);
+  });
+}
+
 testTwoTypesOfLoad('repeated fields', testRepeated);
 testTwoTypesOfLoad('empty repeated fields', testEmptyRepeated);
+testTwoTypesOfLoad('repeated enums', testRepeatedEnum);


### PR DESCRIPTION
## Description

Fixes bugs where serializing an enum within a map or repeated field would treat the enum as a complex type / message.

Fixes #125
