### PR TITLE
fix: switch typescript to tilde notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "mocha": "^11.1.0",
     "pack-n-play": "^3.0.0",
     "protobufjs-cli": "^1.1.3",
-    "typescript": "^5.7.3"
+    "typescript": "~5.8.2"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
TS 5.9.2 has breaking changes in it - this will keep us on 5.8.2 for now. 

Related to googleapis/google-cloud-node-core#106 